### PR TITLE
Add volume mount back to the nginx docker compose entry

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,3 +50,5 @@ services:
       HEADWAY_TILESERVER_URL: http://mbtileserver:8000
     ports:
       - "8080:8080"
+    volumes:
+      - "./data/:/data/:ro"


### PR DESCRIPTION
This should be safe to merge, and necessary for serving the bounding box I believe.