### PR TITLE
Never use cached apt-get update for apt-get install

### DIFF
--- a/mbtiles_build/Dockerfile
+++ b/mbtiles_build/Dockerfile
@@ -1,8 +1,6 @@
 FROM debian:bullseye-slim as bootstrapper
 
-RUN apt-get update -y
-
-RUN apt-get install -y --no-install-recommends wget ca-certificates
+RUN apt-get update -y && apt-get install -y --no-install-recommends wget ca-certificates
 
 COPY download_mirrored_data.sh /
 
@@ -10,9 +8,7 @@ RUN /download_mirrored_data.sh
 
 FROM debian:bullseye-slim
 
-RUN apt-get update -y
-
-RUN apt-get install -y --no-install-recommends curl ca-certificates openjdk-17-jre-headless
+RUN apt-get update -y && apt-get install -y --no-install-recommends curl ca-certificates openjdk-17-jre-headless
 
 WORKDIR /planetiler
 

--- a/tileserver/image/Dockerfile
+++ b/tileserver/image/Dockerfile
@@ -4,8 +4,7 @@ RUN npm install -g tileserver-gl-light
 
 USER root
 
-RUN apt-get update -y
-RUN apt-get install -y gettext-base
+RUN apt-get update -y && apt-get install -y gettext-base
 
 RUN mkdir -p /app/styles
 RUN chown node /app


### PR DESCRIPTION
Self-explanatory. This bit me when I did a docker system prune and rebuilt.