### PR TITLE
Add support for podman

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -129,7 +129,7 @@ services:
     image: pelias/libpostal-service
     restart: always
   pelias_api:
-    image: pelias/api:master
+    image: docker.io/pelias/api:master
     restart: always
     environment:
       PORT: 4000
@@ -142,7 +142,7 @@ services:
       pelias_config_init:
         condition: service_completed_successfully
   peliasplaceholder:
-    image: pelias/placeholder:master
+    image: docker.io/pelias/placeholder:master
     restart: always
     environment:
       PORT: 4100
@@ -155,17 +155,10 @@ services:
       peliasplaceholder_init:
         condition: service_completed_successfully
   peliaselasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: docker.io/pelias/elasticsearch:7.16.1
     restart: always
     volumes:
       - "pelias_elasticsearch_data:/usr/share/elasticsearch/data"
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-      nofile:
-        soft: 65536
-        hard: 65536
     cap_add: ["IPC_LOCK"]
     depends_on:
       pelias_elastic_init:

--- a/services/pelias/pelias.json.template
+++ b/services/pelias/pelias.json.template
@@ -1,49 +1,48 @@
 {
-    "logger": {
-      "level": "info",
-      "timestamp": false
-    },
-    "esclient": {
-      "apiVersion": "7.5",
-      "hosts": [
-        { "host": "peliaselasticsearch" }
-      ]
-    },
-    "elasticsearch": {
-      "settings": {
-        "index": {
-          "refresh_interval": "10s",
-          "number_of_replicas": "0",
-          "number_of_shards": "5"
-        }
-      }
-    },
-    "api": {
-      "services": {
-        "placeholder": { "url": "http://peliasplaceholder:4100" },
-        "libpostal": { "url": "http://peliaslibpostal:4400" }
-      }
-    },
-    "imports": {
-      "adminLookup": {
-        "enabled": true
-      },        
-      "openstreetmap": {
-        "leveldbpath": "/tmp",
-        "datapath": "/data/openstreetmap",
-        "import": [{
-          "filename": "data.osm.pbf"
-        }]
-      },
-      "whosonfirst": {
-        "datapath": "/data/whosonfirst",
-        "countryCode": ${COUNTRY_CODE_LIST},
-        "importPostalcodes": true
-      },
-      "polyline": {
-        "datapath": "/data/polylines",
-        "files": [ "extract.0sv" ]
+  "logger": {
+    "level": "info",
+    "timestamp": false
+  },
+  "esclient": {
+    "apiVersion": "7.5",
+    "hosts": [
+      { "host": "${ELASTICSEARCH_HOST}" }
+    ]
+  },
+  "elasticsearch": {
+    "settings": {
+      "index": {
+        "refresh_interval": "10s",
+        "number_of_replicas": "0",
+        "number_of_shards": "12"
       }
     }
+  },
+  "api": {
+    "services": {
+      "placeholder": { "url": "http://${PLACEHOLDER_HOST}:4100" },
+      "libpostal": { "url": "http://${LIBPOSTAL_HOST}:4400" }
+    }
+  },
+  "imports": {
+    "adminLookup": {
+      "enabled": true
+    },        
+    "openstreetmap": {
+      "leveldbpath": "/tmp",
+      "datapath": "/pdata/openstreetmap",
+      "import": [{
+        "filename": "data.osm.pbf"
+      }]
+    },
+    "whosonfirst": {
+      "datapath": "/pdata/whosonfirst",
+      "countryCode": ${COUNTRY_CODE_LIST},
+      "importPostalcodes": true
+    },
+    "polyline": {
+      "datapath": "/pdata/polylines",
+      "files": [ "extract.0sv" ]
+    }
   }
-  
+}

--- a/services/pelias/podman-compose-import.yaml.template
+++ b/services/pelias/podman-compose-import.yaml.template
@@ -1,0 +1,32 @@
+version: "3"
+services:
+  pelias_schema:
+    image: docker.io/pelias/schema:master
+    container_name: pelias_schema
+    volumes:
+      - "./${AREA}.import.pelias.json:/code/pelias.json"
+      - "../services/pelias/wait.sh:/tools/wait.sh:ro"
+    depends_on:
+      - peliaselasticsearch
+  pelias_openstreetmap:
+    image: docker.io/pelias/openstreetmap:master
+    container_name: pelias_openstreetmap
+    volumes:
+      - "./${AREA}.import.pelias.json:/code/pelias.json"
+      - "./${AREA}.whosonfirst.tar:/pdata/whosonfirst.tar"
+      - "./${AREA}.osm.pbf:/pdata/openstreetmap/data.osm.pbf"
+      - "../services/pelias/wait.sh:/tools/wait.sh:ro"
+      - "wof_data:/pdata/whosonfirst"
+    depends_on:
+      - peliaselasticsearch
+  peliaselasticsearch:
+    image: docker.io/pelias/elasticsearch:7.16.1
+    container_name: pelias_elasticsearch
+    volumes:
+      - "elastic_data:/usr/share/elasticsearch/data"
+    environment:
+      ES_JAVA_OPTS: "-Xmx8g"
+    cap_add: ["IPC_LOCK"]
+volumes:
+  elastic_data:
+  wof_data:


### PR DESCRIPTION
To-do:

- [ ] Document podman build process (notably no more -P flag)
- [ ] Investigate adding podman-based CI job (PIND?)
- [ ] Self-review

Test plan:

- [ ] On a system with Docker only, execute `earthly -P +build --area=Singapore` and confirm that Singapore artifacts are built
- [ ] On that same Docker-only system, execute `docker-compose down --volumes && docker-compose up -d` and verify Headway comes up
- [ ] Check docker system's tileserver
- [ ] Check docker system's pelias
- [ ] Check docker system's valhalla
- [ ] Check docker system's otp
- [ ] On a system with Podman only, execute `earthly +build --area=Singapore` and confirm that Singapore artifacts are built
- [ ] Check podman system's tileserver
- [ ] Check podman system's pelias
- [ ] Check podman system's valhalla
- [ ] Check podman system's otp