### PR TITLE
Don't clobber autocomplete with older request

### DIFF
--- a/web/frontend/src/components/SearchBox.vue
+++ b/web/frontend/src/components/SearchBox.vue
@@ -103,6 +103,8 @@ export default defineComponent({
     const poiSelected: Ref<POI | undefined> = ref(undefined);
     const poiHovered: Ref<POI | undefined> = ref(undefined);
     const autocompleteOptions: Ref<(POI | undefined)[]> = ref([]);
+    let requestIdx = 0;
+    let mostRecentResultsRequestIdx = 0;
 
     var hoverMarker: Marker | undefined = undefined;
 
@@ -123,11 +125,22 @@ export default defineComponent({
       } else {
         url = `/pelias/v1/autocomplete?text=${encodeURIComponent(value)}`;
       }
+      const thisRequestIdx = requestIdx;
+      requestIdx++;
       const response = await fetch(url);
       if (response.status != 200) {
-        autocompleteOptions.value = [];
+        if (thisRequestIdx > mostRecentResultsRequestIdx) {
+          autocompleteOptions.value = [];
+        }
         return;
       }
+      if (thisRequestIdx < mostRecentResultsRequestIdx) {
+        // console.debug(`not updating autocomplete for req #${thisRequestIdx} because req #${mostRecentResultsRequestIdx} completed in the meanwhile.`);
+        return;
+      }
+      // console.debug(`updating autocomplete for req #${thisRequestIdx}`);
+      mostRecentResultsRequestIdx = thisRequestIdx;
+
       const results = await response.json();
       var options: POI[] = [];
       for (const feature of results.features) {

--- a/web/frontend/src/components/SearchBox.vue
+++ b/web/frontend/src/components/SearchBox.vue
@@ -130,15 +130,15 @@ export default defineComponent({
       const response = await fetch(url);
       if (response.status != 200) {
         if (thisRequestIdx > mostRecentResultsRequestIdx) {
+          // Don't clobber existing good results with an error from a stale request
           autocompleteOptions.value = [];
         }
         return;
       }
       if (thisRequestIdx < mostRecentResultsRequestIdx) {
-        // console.debug(`not updating autocomplete for req #${thisRequestIdx} because req #${mostRecentResultsRequestIdx} completed in the meanwhile.`);
+        // not updating autocomplete for a stale req
         return;
       }
-      // console.debug(`updating autocomplete for req #${thisRequestIdx}`);
       mostRecentResultsRequestIdx = thisRequestIdx;
 
       const results = await response.json();


### PR DESCRIPTION
Fixes #152 

Since we issue a lot of requests as we type-ahead, it's easy for them to complete out-of-order.

https://user-images.githubusercontent.com/217057/190509023-80b9af6b-f8f8-48a3-aef0-eaa6cf7e55de.mp4

