### PR TITLE
Don't overzoom large (city-sized) POIs

### DIFF
--- a/web/frontend/src/components/BaseMap.vue
+++ b/web/frontend/src/components/BaseMap.vue
@@ -251,12 +251,18 @@ export default defineComponent({
         this.$data.flyToLocation = { center: location, zoom: zoom };
       }
     },
-    fitBounds: async function (bounds: LngLatBoundsLike) {
+    fitBounds: async function (
+      bounds: LngLatBoundsLike,
+      options: FitBoundsOptions = {}
+    ) {
       const permissionState = await geolocationPermissionState();
+      const defaultOptions = {
+        padding: Math.min(window.innerWidth, window.innerHeight) / 8,
+      };
+      options = { ...defaultOptions, ...(options || {}) };
+
       if (this.$data.hasGeolocated === true || permissionState !== 'granted') {
-        map?.fitBounds(bounds, {
-          padding: Math.min(window.innerWidth, window.innerHeight) / 8,
-        });
+        map?.fitBounds(bounds, options);
       } else {
         this.$data.boundsToFit = bounds;
       }

--- a/web/frontend/src/components/SearchBox.vue
+++ b/web/frontend/src/components/SearchBox.vue
@@ -155,6 +155,7 @@ export default defineComponent({
           address: address,
           key: feature.properties.osm_id,
           position: position,
+          bbox: feature.bbox,
           gid: feature?.properties?.gid,
         });
       }

--- a/web/frontend/src/pages/PlacePage.vue
+++ b/web/frontend/src/pages/PlacePage.vue
@@ -28,9 +28,19 @@ import SearchBox from 'src/components/SearchBox.vue';
 
 async function loadPlacePage(router: Router, canonicalName: string) {
   const poi = await decanonicalizePoi(canonicalName);
+  if (poi === undefined) {
+    return poi;
+  }
 
-  if (poi?.position) {
+  if (poi.bbox) {
+    // prefer bounds when available so we don't "overzoom" on a large
+    // entity like an entire city.
+    getBaseMap()?.fitBounds(poi.bbox);
+  } else if (poi.position) {
     getBaseMap()?.flyTo([poi.position.long, poi.position.lat], 16);
+  }
+
+  if (poi.position) {
     getBaseMap()?.pushMarker(
       'active_marker',
       new Marker({ color: '#111111' }).setLngLat([
@@ -39,8 +49,9 @@ async function loadPlacePage(router: Router, canonicalName: string) {
       ])
     );
     getBaseMap()?.removeMarkersExcept(['active_marker']);
-    return poi;
   }
+
+  return poi;
 }
 
 export default defineComponent({

--- a/web/frontend/src/pages/PlacePage.vue
+++ b/web/frontend/src/pages/PlacePage.vue
@@ -35,7 +35,7 @@ async function loadPlacePage(router: Router, canonicalName: string) {
   if (poi.bbox) {
     // prefer bounds when available so we don't "overzoom" on a large
     // entity like an entire city.
-    getBaseMap()?.fitBounds(poi.bbox);
+    getBaseMap()?.fitBounds(poi.bbox, { maxZoom: 16 });
   } else if (poi.position) {
     getBaseMap()?.flyTo([poi.position.long, poi.position.lat], 16);
   }

--- a/web/frontend/src/utils/models.ts
+++ b/web/frontend/src/utils/models.ts
@@ -72,6 +72,7 @@ export interface POI {
   name?: string | null;
   address?: string | null;
   position?: LongLat;
+  bbox?: [number, number, number, number];
   gid?: string;
 }
 
@@ -137,6 +138,7 @@ export async function decanonicalizePoi(
         address: address,
         key: feature.properties.osm_id,
         position: position,
+        bbox: feature.bbox,
         gid: feature?.properties?.gid,
       };
     }

--- a/web/frontend/src/utils/models.ts
+++ b/web/frontend/src/utils/models.ts
@@ -1,5 +1,5 @@
 import addressFormatter from '@fragaria/address-formatter';
-import {} from 'maplibre-gl';
+import { LngLatBoundsLike } from 'maplibre-gl';
 import { i18n } from 'src/i18n/lang';
 import { LongLat } from './geomath';
 
@@ -72,7 +72,7 @@ export interface POI {
   name?: string | null;
   address?: string | null;
   position?: LongLat;
-  bbox?: [number, number, number, number];
+  bbox?: LngLatBoundsLike;
   gid?: string;
 }
 


### PR DESCRIPTION
This is a followup to #153. Now that you can select localities, the zoom feature feels a little off.

**before**:

![](https://user-images.githubusercontent.com/217057/190867783-b79561de-392a-4f7c-a02b-5ca7b17219e3.mp4)

So now, when available, we prefer to use the bbox for fitting rather than the coordinate. This works much better for large POIs (e.g. "Seattle").

**after zooming to bbox (first commit)**:

![](https://user-images.githubusercontent.com/217057/190867785-99b16955-dd01-4c0b-af46-855f3bebdcd0.mp4)

So zooming in/out to Seattle looks good with the first commit, but zooming into Victrolla loses valuable context of the surrounding neighborhood. This is because, while many small venues are represented as OSM.Nodes, thus lacking a bbox, some (like Vitctrolla) are actually stored as OSM.Ways and thus have a bbox. 

So the second commit introduces a maxZoom, ensuring that if we are zooming to a Bbox we never zoom too close.

**before second commit (too close to small osm ways)**

<img width="868" alt="Screen Shot 2022-09-17 at 10 31 24 AM" src="https://user-images.githubusercontent.com/217057/190867494-cd12354e-3851-4ecb-9151-adf9f225220d.png">

**after second commit (with max zoom)**

<img width="868" alt="Screen Shot 2022-09-17 at 10 30 44 AM" src="https://user-images.githubusercontent.com/217057/190867496-5cd78ec6-4167-494e-8102-93e6a26f7cf5.png">
