### PR TITLE
add securityContext to k8s manifests

### DIFF
--- a/k8s/elasticsearch-deployment.yaml
+++ b/k8s/elasticsearch-deployment.yaml
@@ -33,6 +33,10 @@ spec:
       initContainers:
         - name: pelias-init
           image: ghcr.io/headwaymaps/pelias-init:maps-dot-earth
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
           imagePullPolicy: Always
           volumeMounts:
             - name: elasticsearch-volume
@@ -64,6 +68,10 @@ spec:
       containers:
         - name: pelias-elasticsearch
           image: pelias/elasticsearch:7.16.1
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
           volumeMounts:
             - name: elasticsearch-volume
               mountPath: /usr/share/elasticsearch/data

--- a/k8s/headway-deployment.yaml
+++ b/k8s/headway-deployment.yaml
@@ -24,6 +24,10 @@ spec:
       initContainers:
         - name: headway-init
           image: ghcr.io/headwaymaps/headway-init:maps-dot-earth
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
           imagePullPolicy: Always
           volumeMounts:
             - name: headway-volume
@@ -51,6 +55,10 @@ spec:
       containers:
         - name: headway
           image: ghcr.io/headwaymaps/headway:maps-dot-earth
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
           imagePullPolicy: Always
           volumeMounts:
             - name: headway-volume

--- a/k8s/libpostal-deployment.yaml
+++ b/k8s/libpostal-deployment.yaml
@@ -16,6 +16,10 @@ spec:
       containers:
         - name: pelias-libpostal
           image: pelias/libpostal-service:latest
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
           imagePullPolicy: Always
           ports:
             - containerPort: 4400

--- a/k8s/opentripplanner-deployment.yaml
+++ b/k8s/opentripplanner-deployment.yaml
@@ -15,6 +15,10 @@ spec:
       initContainers:
         - name: opentripplanner-init
           image: ghcr.io/headwaymaps/opentripplanner-init:maps-dot-earth
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
           imagePullPolicy: Always
           volumeMounts:
             - name: opentripplanner-volume
@@ -35,6 +39,10 @@ spec:
       containers:
         - name: opentripplanner
           image: ghcr.io/headwaymaps/opentripplanner:maps-dot-earth
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
           imagePullPolicy: Always
           ports:
             - containerPort: 8000

--- a/k8s/pelias-api-deployment.yaml
+++ b/k8s/pelias-api-deployment.yaml
@@ -23,6 +23,10 @@ spec:
       initContainers:
         - name: pelias-init
           image: ghcr.io/headwaymaps/pelias-init:maps-dot-earth
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume
@@ -47,6 +51,10 @@ spec:
       containers:
         - name: pelias-api
           image: pelias/api:latest
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
           ports:
             - containerPort: 4000
           volumeMounts:

--- a/k8s/placeholder-deployment.yaml
+++ b/k8s/placeholder-deployment.yaml
@@ -17,6 +17,10 @@ spec:
       initContainers:
         - name: pelias-init
           image: ghcr.io/headwaymaps/pelias-init:maps-dot-earth
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
           imagePullPolicy: Always
           volumeMounts:
             - name: placeholder-volume
@@ -48,6 +52,10 @@ spec:
       containers:
         - name: pelias-placeholder
           image: pelias/placeholder:latest
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
           ports:
             - containerPort: 4100
           volumeMounts:

--- a/k8s/tileserver-deployment.yaml
+++ b/k8s/tileserver-deployment.yaml
@@ -15,6 +15,10 @@ spec:
       initContainers:
         - name: tileserver-init
           image: ghcr.io/headwaymaps/tileserver-init:maps-dot-earth
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
           imagePullPolicy: Always
           volumeMounts:
             - name: tileserver-volume
@@ -44,6 +48,10 @@ spec:
       containers:
         - name: tileserver
           image: ghcr.io/headwaymaps/tileserver:maps-dot-earth
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
           imagePullPolicy: Always
           ports:
             - containerPort: 8000

--- a/k8s/valhalla-deployment.yaml
+++ b/k8s/valhalla-deployment.yaml
@@ -15,6 +15,10 @@ spec:
       initContainers:
         - name: valhalla-init
           image: ghcr.io/headwaymaps/valhalla-init:maps-dot-earth
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
           imagePullPolicy: Always
           volumeMounts:
             - name: valhalla-volume
@@ -40,6 +44,10 @@ spec:
       containers:
         - name: valhalla
           image: ghcr.io/headwaymaps/valhalla:maps-dot-earth
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
           ports:
           - containerPort: 8002
           volumeMounts:


### PR DESCRIPTION
K8s is not secure by default, so I added some basic security best practices to apply with the [CISA Harding guide](https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF).

I ran headway with the updated manifests to verify this change is not breaking something.