### PR TITLE
FIX: url doesn't update for subsequent searches

### DIFF
--- a/web/frontend/src/pages/PlacePage.vue
+++ b/web/frontend/src/pages/PlacePage.vue
@@ -15,21 +15,14 @@
 <script lang="ts">
 import { Marker } from 'maplibre-gl';
 import { getBaseMap } from 'src/components/BaseMap.vue';
-import {
-  encodePoi,
-  decanonicalizePoi,
-  POI,
-  poiDisplayName,
-} from 'src/utils/models';
+import { decanonicalizePoi, POI, poiDisplayName } from 'src/utils/models';
 import PlaceCard from 'src/components/PlaceCard.vue';
 import { defineComponent } from 'vue';
-import { Router } from 'vue-router';
 import SearchBox from 'src/components/SearchBox.vue';
 
-async function loadPlacePage(router: Router, canonicalName: string) {
-  const poi = await decanonicalizePoi(canonicalName);
+async function loadPlacePage(poi: POI | undefined) {
   if (poi === undefined) {
-    return poi;
+    return;
   }
 
   if (poi.bbox) {
@@ -50,8 +43,6 @@ async function loadPlacePage(router: Router, canonicalName: string) {
     );
     getBaseMap()?.removeMarkersExcept(['active_marker']);
   }
-
-  return poi;
 }
 
 export default defineComponent({
@@ -70,7 +61,7 @@ export default defineComponent({
     poi(newValue) {
       setTimeout(async () => {
         if (newValue) {
-          await loadPlacePage(this.$router, encodePoi(newValue));
+          await loadPlacePage(this.$router, newValue);
           this.$emit('loadedPoi', this.$data.poi);
         } else {
           this.$router.push('/');
@@ -92,9 +83,10 @@ export default defineComponent({
   },
   mounted: async function () {
     setTimeout(async () => {
+      const poi = await decanonicalizePoi(this.$props.osm_id);
       this.$data.poi = (await loadPlacePage(
         this.$router,
-        this.$props.osm_id as string
+        poi
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       )) as any;
       this.$emit('loadedPoi', this.$data.poi);

--- a/web/frontend/src/pages/PlacePage.vue
+++ b/web/frontend/src/pages/PlacePage.vue
@@ -20,11 +20,7 @@ import PlaceCard from 'src/components/PlaceCard.vue';
 import { defineComponent } from 'vue';
 import SearchBox from 'src/components/SearchBox.vue';
 
-async function renderOnMap(poi: POI | undefined) {
-  if (poi === undefined) {
-    return;
-  }
-
+async function renderOnMap(poi: POI) {
   if (poi.bbox) {
     // prefer bounds when available so we don't "overzoom" on a large
     // entity like an entire city.
@@ -65,8 +61,12 @@ export default defineComponent({
     const poi = await decanonicalizePoi(this.$props.osm_id);
     this.$data.poi = poi;
 
-    await renderOnMap(poi);
-    this.$emit('loadedPoi', poi);
+    if (poi) {
+      await renderOnMap(poi);
+      this.$emit('loadedPoi', poi);
+    } else {
+      console.warn(`unable to find POI with osm_id: ${this.$props.osm_id}`);
+    }
 
     // watch *after* initial render
     this.$watch('poi', async (newValue) => {

--- a/web/frontend/src/pages/PlacePage.vue
+++ b/web/frontend/src/pages/PlacePage.vue
@@ -58,10 +58,16 @@ export default defineComponent({
     };
   },
   watch: {
-    poi(newValue) {
+    poi(newValue, oldValue) {
       setTimeout(async () => {
         if (newValue) {
-          await loadPlacePage(this.$router, newValue);
+          // Update the path if the POI has changed _after_ the initial page
+          // load.
+          if (oldValue?.gid) {
+            const gidComponent = encodeURIComponent(newValue.gid);
+            this.$router.push(`/place/${gidComponent}`);
+          }
+          await loadPlacePage(newValue);
           this.$emit('loadedPoi', this.$data.poi);
         } else {
           this.$router.push('/');
@@ -71,26 +77,9 @@ export default defineComponent({
   },
   methods: {
     poiDisplayName,
-    poiSelected: function (poi?: POI) {
-      getBaseMap()?.removeMarkersExcept([]);
-      if (poi?.gid) {
-        const gidComponent = encodeURIComponent(poi?.gid);
-        this.$router.push(`/place/${gidComponent}`);
-      } else {
-        this.$router.push('/');
-      }
-    },
   },
   mounted: async function () {
-    setTimeout(async () => {
-      const poi = await decanonicalizePoi(this.$props.osm_id);
-      this.$data.poi = (await loadPlacePage(
-        this.$router,
-        poi
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      )) as any;
-      this.$emit('loadedPoi', this.$data.poi);
-    });
+    this.$data.poi = await decanonicalizePoi(this.$props.osm_id);
   },
   setup: function () {
     return {};


### PR DESCRIPTION
FIXES: #166

I left my individual commits in case you want to follow the commit log narrative, but feel free to squash as you see fit:

- refactor: avoid unnecessary round trip
- update path on subsequent reloads
- clearer code
- restore error handling if given invalid osm_id

