### PR TITLE
Start zoomed on last location when possible.

### DIFF
--- a/web/frontend/src/utils/Prefs.test.ts
+++ b/web/frontend/src/utils/Prefs.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from '@jest/globals';
+import { LngLat } from 'maplibre-gl';
+import Prefs from './Prefs';
+
+/**
+ * For testing without using localStorage.
+ */
+class UnpersistedStorage implements Storage {
+  items = new Map<string, string>();
+
+  get length(): number {
+    return this.items.size;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  key(index: number): string {
+    throw 'unimplemented';
+  }
+
+  getItem(key: string): string | null {
+    const value = this.items.get(key);
+    if (value === undefined) {
+      // conform to Storage interface
+      return null;
+    } else {
+      return value;
+    }
+  }
+
+  setItem(key: string, value: string) {
+    this.items.set(key, value);
+  }
+
+  removeItem(key: string) {
+    this.items.delete(key);
+  }
+
+  clear() {
+    this.items.clear();
+  }
+}
+
+test('unpersisted storage', () => {
+  const storage = new UnpersistedStorage();
+  expect(storage.getItem('foo')).toBeNull();
+  expect(storage.length).toBe(0);
+
+  storage.setItem('foo', 'bar');
+  expect(storage.getItem('foo')).toBe('bar');
+  expect(storage.length).toBe(1);
+
+  storage.removeItem('foo');
+  expect(storage.getItem('foo')).toBeNull();
+  expect(storage.length).toBe(0);
+
+  storage.setItem('foo', 'bar');
+  storage.clear();
+  expect(storage.getItem('foo')).toBeNull();
+  expect(storage.length).toBe(0);
+});
+
+test('most recent center', () => {
+  const storage = new UnpersistedStorage();
+  const prefs = new Prefs(storage);
+  expect(prefs.mostRecentMapCenter()).toBe(null);
+
+  prefs.setMostRecentMapCenter(new LngLat(1.0, 2.0));
+  expect(prefs.mostRecentMapCenter()).toStrictEqual([1.0, 2.0]);
+
+  prefs.setMostRecentMapCenter(new LngLat(3.0, 4.0));
+  prefs.setMostRecentMapCenter([5.0, 6.0]);
+  expect(prefs.mostRecentMapCenter()).toStrictEqual([5.0, 6.0]);
+});

--- a/web/frontend/src/utils/Prefs.ts
+++ b/web/frontend/src/utils/Prefs.ts
@@ -1,0 +1,102 @@
+import { LngLat, LngLatLike } from 'maplibre-gl';
+import { isEqual } from 'lodash';
+
+export default class Prefs {
+  private static _stored: Prefs | undefined;
+  static stored(): Prefs {
+    if (Prefs._stored === undefined) {
+      Prefs._stored = new Prefs(window.localStorage);
+    }
+    return Prefs._stored;
+  }
+
+  private storage: Storage;
+
+  constructor(storage: Storage) {
+    this.storage = storage;
+  }
+
+  private _mostRecentMapZoom: number | undefined | null;
+  mostRecentMapZoom(): number | null {
+    if (this._mostRecentMapZoom !== undefined) {
+      return this._mostRecentMapZoom;
+    }
+    const json = this.storage.getItem('mostRecentMapZoom');
+    if (!json) {
+      return null;
+    }
+    let value;
+    try {
+      value = JSON.parse(json);
+    } catch (e) {
+      console.warn('invalid json stored for map zoom:', json);
+      return null;
+    }
+
+    if (typeof value === 'number') {
+      this._mostRecentMapZoom = value;
+      return value;
+    } else {
+      console.warn('invalid value stored for map zoom:', value);
+      return null;
+    }
+  }
+
+  setMostRecentMapZoom(zoom: number) {
+    if (zoom == this._mostRecentMapZoom) {
+      // no-op, avoid writing to storage.
+      return;
+    }
+
+    const json = JSON.stringify(zoom);
+    this.storage.setItem('mostRecentMapZoom', json);
+    this._mostRecentMapZoom = zoom;
+  }
+
+  private _mostRecentMapCenter: LngLatLike | undefined | null;
+  mostRecentMapCenter(): LngLatLike | null {
+    if (this._mostRecentMapCenter !== undefined) {
+      return this._mostRecentMapCenter;
+    }
+
+    const json = this.storage.getItem('mostRecentMapCenter');
+    if (!json) {
+      return null;
+    }
+
+    let value;
+    try {
+      value = JSON.parse(json);
+    } catch (e) {
+      console.warn('invalid json stored for map center:', json);
+      return null;
+    }
+
+    if (Array.isArray(value) && value.length == 2) {
+      const center = value as [number, number];
+      this._mostRecentMapCenter = center;
+      return center;
+    } else {
+      console.warn('invalid value stored for map center:', value);
+      return null;
+    }
+  }
+
+  setMostRecentMapCenter(lnglat: LngLatLike) {
+    const coords = LngLat.convert(lnglat).toArray();
+
+    if (isEqual(coords, [0, 0])) {
+      // don't store null island
+      return;
+    }
+
+    if (isEqual(coords, this._mostRecentMapCenter)) {
+      // no-op, avoid writing to storage.
+      return;
+    }
+
+    const json = JSON.stringify(coords);
+    this.storage.setItem('mostRecentMapCenter', json);
+    this._mostRecentMapCenter = coords as [number, number];
+  }
+}


### PR DESCRIPTION
Fixes #167 

To do this, we store previous map center and zoom in localStorage.

There's some special care taken to not store/fetch too often. Maybe this
is overkill with the debounce, but it seemed wasteful to potentially
trigger i/o as the user pans around or zooms in.

We also recall the users previous zoom - we wouldn't want to zoom in
*further* then they were previously zoomed. That could be particularly
disorienting if the user was at a global scale looking at an ocean or
something.

TBH this risk still exists if the user accidentally zooms way into an
ocean before closing their browser. It'd be nice to have some kind of
magic "is user staring at the ocean" check to short circuit this
behavior, but I _think_, even without that, the risk is worth trying out
the new UI.


Demo:

https://user-images.githubusercontent.com/217057/191879920-c4a2a2e1-6081-4735-8928-a6587130781c.mp4


