### PR TITLE
faster deploys with zstd

### DIFF
--- a/bin/publish-data
+++ b/bin/publish-data
@@ -59,17 +59,16 @@ else
     exit 1
 fi
 
-upload "${AREA}.valhalla.tar.xz"      "${HEADWAY_VERSION}/${AREA_TAG}"
-upload "${AREA}.pelias.json"          "${HEADWAY_VERSION}/${AREA_TAG}"
-upload "${AREA}.elasticsearch.tar.xz" "${HEADWAY_VERSION}/${AREA_TAG}"
+upload "${AREA}.valhalla.tar.zst"      "${HEADWAY_VERSION}/${AREA_TAG}"
+upload "${AREA}.elasticsearch.tar.zst" "${HEADWAY_VERSION}/${AREA_TAG}"
 upload "${AREA}.mbtiles"              "${HEADWAY_VERSION}/${AREA_TAG}"
-upload "${AREA}.placeholder.tar.xz"   "${HEADWAY_VERSION}/${AREA_TAG}"
+upload "${AREA}.placeholder.tar.zst"   "${HEADWAY_VERSION}/${AREA_TAG}"
 upload "${AREA}.osm.pbf"              "${HEADWAY_VERSION}/${AREA_TAG}"
 
 # transit files only exist when transit is enabled
-if [ -f "${DATA_ROOT}/${AREA}.graph.obj.xz" ]; then
-upload "${AREA}.graph.obj.xz"         "${HEADWAY_VERSION}/${AREA_TAG}"
-upload "${AREA}.gtfs.tar.xz"          "${HEADWAY_VERSION}/${AREA_TAG}"
+if [ -f "${DATA_ROOT}/${AREA}.graph.obj.zst" ]; then
+upload "${AREA}.graph.obj.zst"         "${HEADWAY_VERSION}/${AREA_TAG}"
+upload "${AREA}.gtfs.tar.zst"          "${HEADWAY_VERSION}/${AREA_TAG}"
 fi
 
 # These files are generic across all areas

--- a/docker-compose-with-transit.yaml
+++ b/docker-compose-with-transit.yaml
@@ -28,7 +28,7 @@ services:
     image: ghcr.io/headwaymaps/opentripplanner-init:latest
     env_file: .env
     environment:
-      OTP_ARTIFACT_SOURCE_PATH: /bootstrap/${HEADWAY_AREA}.graph.obj.xz
+      OTP_ARTIFACT_SOURCE_PATH: /bootstrap/${HEADWAY_AREA}.graph.obj.zst
     volumes:
       - "./data/:/bootstrap/:ro"
       - "opentripplanner_data:/data/:rw"
@@ -48,7 +48,7 @@ services:
       - "valhalla_data:/data/:rw"
       - "./data/:/bootstrap/:ro"
     environment:
-      VALHALLA_ARTIFACT_SOURCE_PATH: /bootstrap/${HEADWAY_AREA}.valhalla.tar.xz
+      VALHALLA_ARTIFACT_SOURCE_PATH: /bootstrap/${HEADWAY_AREA}.valhalla.tar.zst
     ulimits:
       nofile:
         soft: 8192
@@ -109,7 +109,7 @@ services:
     image: ghcr.io/headwaymaps/pelias-init:latest
     env_file: .env
     environment:
-      ELASTICSEARCH_ARTIFACT_SOURCE_PATH: /bootstrap/${HEADWAY_AREA}.elasticsearch.tar.xz
+      ELASTICSEARCH_ARTIFACT_SOURCE_PATH: /bootstrap/${HEADWAY_AREA}.elasticsearch.tar.zst
     command: [ "/bin/bash", "/app/init_elastic.sh" ]
     volumes:
       - "./data/:/bootstrap/:ro"
@@ -118,7 +118,7 @@ services:
     image: ghcr.io/headwaymaps/pelias-init:latest
     env_file: .env
     environment:
-      PLACEHOLDER_ARTIFACT_SOURCE_PATH: /bootstrap/${HEADWAY_AREA}.placeholder.tar.xz
+      PLACEHOLDER_ARTIFACT_SOURCE_PATH: /bootstrap/${HEADWAY_AREA}.placeholder.tar.zst
     command: [ "/bin/bash", "/app/init_placeholder.sh" ]
     volumes:
       - "./data/:/bootstrap/:ro"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
       - "valhalla_data:/data/:rw"
       - "./data/:/bootstrap/:ro"
     environment:
-      VALHALLA_ARTIFACT_SOURCE_PATH: /bootstrap/${HEADWAY_AREA}.valhalla.tar.xz
+      VALHALLA_ARTIFACT_SOURCE_PATH: /bootstrap/${HEADWAY_AREA}.valhalla.tar.zst
     ulimits:
       nofile:
         soft: 8192
@@ -92,7 +92,7 @@ services:
     image: ghcr.io/headwaymaps/pelias-init:latest
     env_file: .env
     environment:
-      ELASTICSEARCH_ARTIFACT_SOURCE_PATH: /bootstrap/${HEADWAY_AREA}.elasticsearch.tar.xz
+      ELASTICSEARCH_ARTIFACT_SOURCE_PATH: /bootstrap/${HEADWAY_AREA}.elasticsearch.tar.zst
     command: [ "/bin/bash", "/app/init_elastic.sh" ]
     volumes:
       - "./data/:/bootstrap/:ro"
@@ -101,7 +101,7 @@ services:
     image: ghcr.io/headwaymaps/pelias-init:latest
     env_file: .env
     environment:
-      PLACEHOLDER_ARTIFACT_SOURCE_PATH: /bootstrap/${HEADWAY_AREA}.placeholder.tar.xz
+      PLACEHOLDER_ARTIFACT_SOURCE_PATH: /bootstrap/${HEADWAY_AREA}.placeholder.tar.zst
     command: [ "/bin/bash", "/app/init_placeholder.sh" ]
     volumes:
       - "./data/:/bootstrap/:ro"

--- a/k8s/_template/deployment-config.yaml.tpl
+++ b/k8s/_template/deployment-config.yaml.tpl
@@ -11,8 +11,8 @@ data:
   sprite-source-url: ${HEADWAY_K8S_ARTIFACT_ROOT}/${ASSET_VERSION}/sprite.tar
   natural-earth-source-url: ${HEADWAY_K8S_ARTIFACT_ROOT}/${ASSET_VERSION}/natural_earth.mbtiles
   mbtiles-source-url: ${HEADWAY_K8S_ARTIFACT_ROOT}/${ASSET_VERSION}/${HEADWAY_AREA_TAG}/${HEADWAY_AREA}.mbtiles
-  valhalla-artifact-url: ${HEADWAY_K8S_ARTIFACT_ROOT}/${ASSET_VERSION}/${HEADWAY_AREA_TAG}/${HEADWAY_AREA}.valhalla.tar.xz
-  placeholder-artifact-url: ${HEADWAY_K8S_ARTIFACT_ROOT}/${ASSET_VERSION}/${HEADWAY_AREA_TAG}/${HEADWAY_AREA}.placeholder.tar.xz
-  elasticsearch-artifact-url: ${HEADWAY_K8S_ARTIFACT_ROOT}/${ASSET_VERSION}/${HEADWAY_AREA_TAG}/${HEADWAY_AREA}.elasticsearch.tar.xz
-  otp-graph-url: ${HEADWAY_K8S_ARTIFACT_ROOT}/${ASSET_VERSION}/${HEADWAY_AREA_TAG}/${HEADWAY_AREA}.graph.obj.xz
+  valhalla-artifact-url: ${HEADWAY_K8S_ARTIFACT_ROOT}/${ASSET_VERSION}/${HEADWAY_AREA_TAG}/${HEADWAY_AREA}.valhalla.tar.zst
+  placeholder-artifact-url: ${HEADWAY_K8S_ARTIFACT_ROOT}/${ASSET_VERSION}/${HEADWAY_AREA_TAG}/${HEADWAY_AREA}.placeholder.tar.zst
+  elasticsearch-artifact-url: ${HEADWAY_K8S_ARTIFACT_ROOT}/${ASSET_VERSION}/${HEADWAY_AREA_TAG}/${HEADWAY_AREA}.elasticsearch.tar.zst
+  otp-graph-url: ${HEADWAY_K8S_ARTIFACT_ROOT}/${ASSET_VERSION}/${HEADWAY_AREA_TAG}/${HEADWAY_AREA}.graph.obj.zst
   pelias-config-json: ${PELIAS_CONFIG_JSON_YAML}

--- a/k8s/los-angeles-latest-hw-dev/deployment-config.yaml
+++ b/k8s/los-angeles-latest-hw-dev/deployment-config.yaml
@@ -11,10 +11,10 @@ data:
   sprite-source-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/dev/sprite.tar
   natural-earth-source-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/dev/natural_earth.mbtiles
   mbtiles-source-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/dev/los-angeles-latest/los-angeles-latest.mbtiles
-  valhalla-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/dev/los-angeles-latest/los-angeles-latest.valhalla.tar.xz
-  placeholder-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/dev/los-angeles-latest/los-angeles-latest.placeholder.tar.xz
-  elasticsearch-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/dev/los-angeles-latest/los-angeles-latest.elasticsearch.tar.xz
-  otp-graph-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/dev/los-angeles-latest/los-angeles-latest.graph.obj.xz
+  valhalla-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/dev/los-angeles-latest/los-angeles-latest.valhalla.tar.zst
+  placeholder-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/dev/los-angeles-latest/los-angeles-latest.placeholder.tar.zst
+  elasticsearch-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/dev/los-angeles-latest/los-angeles-latest.elasticsearch.tar.zst
+  otp-graph-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/dev/los-angeles-latest/los-angeles-latest.graph.obj.zst
   pelias-config-json: |
     {
       "logger": {

--- a/k8s/planet-with-admin-v1.20-hw-0.1.0/deployment-config.yaml
+++ b/k8s/planet-with-admin-v1.20-hw-0.1.0/deployment-config.yaml
@@ -11,10 +11,10 @@ data:
   sprite-source-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.1.0/sprite.tar
   natural-earth-source-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.1.0/natural_earth.mbtiles
   mbtiles-source-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.1.0/planet-with-admin-v1.20/planet-with-admin-v1.20.mbtiles
-  valhalla-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.1.0/planet-with-admin-v1.20/planet-with-admin-v1.20.valhalla.tar.xz
-  placeholder-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.1.0/planet-with-admin-v1.20/planet-with-admin-v1.20.placeholder.tar.xz
-  elasticsearch-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.1.0/planet-with-admin-v1.20/planet-with-admin-v1.20.elasticsearch.tar.xz
-  otp-graph-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.1.0/planet-with-admin-v1.20/planet-with-admin-v1.20.graph.obj.xz
+  valhalla-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.1.0/planet-with-admin-v1.20/planet-with-admin-v1.20.valhalla.tar.zst
+  placeholder-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.1.0/planet-with-admin-v1.20/planet-with-admin-v1.20.placeholder.tar.zst
+  elasticsearch-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.1.0/planet-with-admin-v1.20/planet-with-admin-v1.20.elasticsearch.tar.zst
+  otp-graph-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.1.0/planet-with-admin-v1.20/planet-with-admin-v1.20.graph.obj.zst
   pelias-config-json: |
     {
       "logger": {

--- a/k8s/planet-with-admin-v1.20-hw-dev/deployment-config.yaml
+++ b/k8s/planet-with-admin-v1.20-hw-dev/deployment-config.yaml
@@ -11,10 +11,10 @@ data:
   sprite-source-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.1.0/sprite.tar
   natural-earth-source-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.1.0/natural_earth.mbtiles
   mbtiles-source-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.1.0/planet-with-admin-v1.20/planet-with-admin-v1.20.mbtiles
-  valhalla-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.1.0/planet-with-admin-v1.20/planet-with-admin-v1.20.valhalla.tar.xz
-  placeholder-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.1.0/planet-with-admin-v1.20/planet-with-admin-v1.20.placeholder.tar.xz
-  elasticsearch-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.1.0/planet-with-admin-v1.20/planet-with-admin-v1.20.elasticsearch.tar.xz
-  otp-graph-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.1.0/planet-with-admin-v1.20/planet-with-admin-v1.20.graph.obj.xz
+  valhalla-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.1.0/planet-with-admin-v1.20/planet-with-admin-v1.20.valhalla.tar.zst
+  placeholder-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.1.0/planet-with-admin-v1.20/planet-with-admin-v1.20.placeholder.tar.zst
+  elasticsearch-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.1.0/planet-with-admin-v1.20/planet-with-admin-v1.20.elasticsearch.tar.zst
+  otp-graph-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.1.0/planet-with-admin-v1.20/planet-with-admin-v1.20.graph.obj.zst
   pelias-config-json: |
     {
       "logger": {

--- a/k8s/seattle-latest-hw-dev/deployment-config.yaml
+++ b/k8s/seattle-latest-hw-dev/deployment-config.yaml
@@ -11,10 +11,10 @@ data:
   sprite-source-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/dev/sprite.tar
   natural-earth-source-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/dev/natural_earth.mbtiles
   mbtiles-source-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/dev/seattle-latest/Seattle.mbtiles
-  valhalla-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/dev/seattle-latest/Seattle.valhalla.tar.xz
-  placeholder-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/dev/seattle-latest/Seattle.placeholder.tar.xz
-  elasticsearch-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/dev/seattle-latest/Seattle.elasticsearch.tar.xz
-  otp-graph-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/dev/seattle-latest/Seattle.graph.obj.xz
+  valhalla-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/dev/seattle-latest/Seattle.valhalla.tar.zst
+  placeholder-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/dev/seattle-latest/Seattle.placeholder.tar.zst
+  elasticsearch-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/dev/seattle-latest/Seattle.elasticsearch.tar.zst
+  otp-graph-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/dev/seattle-latest/Seattle.graph.obj.zst
   pelias-config-json: |
     {
       "logger": {

--- a/services/otp/init.sh
+++ b/services/otp/init.sh
@@ -7,10 +7,10 @@ if [ -f /data/graph.obj ]; then
     echo "Nothing to do, already have ${OTP_ARTIFACT_DEST_PATH}"
 elif [ -f "${OTP_ARTIFACT_SOURCE_PATH}" ]; then
     echo "Copying artifact."
-    xz --decompress --stdout "${OTP_ARTIFACT_SOURCE_PATH}" > /data/graph.obj
+    zstd --decompress --stdout "${OTP_ARTIFACT_SOURCE_PATH}" > /data/graph.obj
 elif [ ! -z "${OTP_ARTIFACT_URL}" ]; then
     echo "Downloading artifact"
-    wget --tries=100 --continue -O- "${OTP_ARTIFACT_URL}" | xz --decompress --stdout > /data/graph.obj.download
+    wget --tries=100 --continue -O- "${OTP_ARTIFACT_URL}" | zstd --decompress --stdout > /data/graph.obj.download
     mv /data/graph.obj.download /data/graph.obj
 else
     echo "No OTP artifact available."

--- a/services/pelias/init_elastic.sh
+++ b/services/pelias/init_elastic.sh
@@ -8,12 +8,12 @@ if [ ! -z "$(find /usr/share/elasticsearch/data -type f)" ]; then
 elif [ -f "${ELASTICSEARCH_ARTIFACT_SOURCE_PATH}" ]; then
     echo "Extracting artifact."
     mkdir -p /usr/share/elasticsearch/data
-    tar -xJf "${ELASTICSEARCH_ARTIFACT_SOURCE_PATH}" -C /usr/share/elasticsearch/data
+    tar --zstd -xf "${ELASTICSEARCH_ARTIFACT_SOURCE_PATH}" -C /usr/share/elasticsearch/data
 elif [ ! -z "${ELASTICSEARCH_ARTIFACT_URL}" ]; then
     echo "Downloading and extracting artifact."
     rm -fr /tmp/elasticsearch.download
     mkdir -p /tmp/elasticsearch.download
-    wget --tries=100 -O- "${ELASTICSEARCH_ARTIFACT_URL}" | tar -xJ -C /tmp/elasticsearch.download
+    wget --tries=100 -O- "${ELASTICSEARCH_ARTIFACT_URL}" | tar --zstd -x -C /tmp/elasticsearch.download
     mv /tmp/elasticsearch.download/nodes /usr/share/elasticsearch/data/nodes
     rmdir /tmp/elasticsearch.download
 else

--- a/services/pelias/init_placeholder.sh
+++ b/services/pelias/init_placeholder.sh
@@ -8,12 +8,12 @@ if [ ! -z "$(ls -A /data/placeholder)" ]; then
 elif [ -f "${PLACEHOLDER_ARTIFACT_SOURCE_PATH}" ]; then
     echo "Extracting artifact."
     mkdir -p /data/placeholder
-    tar -xJf "${PLACEHOLDER_ARTIFACT_SOURCE_PATH}" -C /data/placeholder
+    tar --zstd -xf "${PLACEHOLDER_ARTIFACT_SOURCE_PATH}" -C /data/placeholder
 elif [ ! -z "${PLACEHOLDER_ARTIFACT_URL}" ]; then
     echo "Downloading and extracting artifact."
     rm -fr /tmp/placeholder.download
     mkdir -p /tmp/placeholder.download
-    wget --tries=100 -O- "${PLACEHOLDER_ARTIFACT_URL}" | tar -xJ -C /tmp/placeholder.download
+    wget --tries=100 -O- "${PLACEHOLDER_ARTIFACT_URL}" | tar --zstd -x -C /tmp/placeholder.download
     mv /tmp/placeholder.download /data/placeholder
 else
     echo "No placeholder artifact available."

--- a/services/valhalla/init.sh
+++ b/services/valhalla/init.sh
@@ -12,10 +12,10 @@ mkdir -p /data/valhalla/
 
 if [ -f "${VALHALLA_ARTIFACT_SOURCE_PATH}" ]; then
     echo "Copying artifact."
-    xz --decompress --stdout ${VALHALLA_ARTIFACT_SOURCE_PATH} > /data/valhalla/tiles.tar
+    zstd --decompress --stdout ${VALHALLA_ARTIFACT_SOURCE_PATH} > /data/valhalla/tiles.tar
 elif [ ! -z "${VALHALLA_ARTIFACT_URL}" ]; then
     echo "Downloading artifact."
-    wget --tries=100 -O- "${VALHALLA_ARTIFACT_URL}" | xz --decompress --stdout > /data/valhalla/tiles.tar.download
+    wget --tries=100 -O- "${VALHALLA_ARTIFACT_URL}" | zstd --decompress --stdout > /data/valhalla/tiles.tar.download
     mv /data/valhalla/tiles.tar.download /data/valhalla/tiles.tar
 else
     echo "No valhalla artifact available."


### PR DESCRIPTION
- Decreases decompression speed by about 10x (big yay!)
- Increases file size by about 0.3x (small boo!)

It also substantially increases compression speed, but I don't care so much about that as it only happens once when building assets, not on every deploy.

For me, and I expect many, decompression speed is the bottleneck, not
bandwidth. If you are on a slow network or have a very fast machine,
it's possible that decompression speed isn't your bottleneck and that
this change could be a little worse for you.

For everyone else (like me), you could expect up to about a 7x increase
in artifact deployment speed, less if your network gets saturated.

<details>
<summary>
Speed:
</summary>

```
++ xz -k input/Seattle.elasticsearch.tar --stdout
real    1m56.604s
user    1m56.380s
sys     0m0.220s
++ xz -d -k xz/Seattle.elasticsearch.tar.xz --stdout
real    0m9.812s
user    0m9.557s
sys     0m0.240s
++ zstd -k input/Seattle.elasticsearch.tar --stdout
real    0m1.961s
user    0m2.022s
sys     0m0.225s
++ zstd -d -k zstd/Seattle.elasticsearch.tar.zstd --stdout
real    0m0.654s
user    0m0.451s
sys     0m0.203s

++ xz -k input/Seattle.graph.obj --stdout
real    0m49.401s
user    0m49.339s
sys     0m0.052s
++ xz -d -k xz/Seattle.graph.obj.xz --stdout
real    0m2.400s
user    0m2.300s
sys     0m0.100s
++ zstd -k input/Seattle.graph.obj --stdout
real    0m0.715s
user    0m0.727s
sys     0m0.095s
++ zstd -d -k zstd/Seattle.graph.obj.zstd --stdout
real    0m0.299s
user    0m0.222s
sys     0m0.077s

++ xz -k input/Seattle.gtfs.tar --stdout
real    0m8.583s
user    0m8.551s
sys     0m0.032s
++ xz -d -k xz/Seattle.gtfs.tar.xz --stdout
real    0m1.282s
user    0m1.254s
sys     0m0.028s
++ zstd -k input/Seattle.gtfs.tar --stdout
real    0m0.130s
user    0m0.129s
sys     0m0.028s
++ zstd -d -k zstd/Seattle.gtfs.tar.zstd --stdout
real    0m0.047s
user    0m0.020s
sys     0m0.027s

++ xz -k input/Seattle.placeholder.tar --stdout
real    2m33.522s
user    2m33.358s
sys     0m0.160s
++ xz -d -k xz/Seattle.placeholder.tar.xz --stdout
real    0m5.100s
user    0m4.804s
sys     0m0.296s
++ zstd -k input/Seattle.placeholder.tar --stdout
real    0m1.915s
user    0m1.938s
sys     0m0.224s
++ zstd -d -k zstd/Seattle.placeholder.tar.zstd --stdout
real    0m0.800s
user    0m0.548s
sys     0m0.252s

++ xz -k input/Seattle.valhalla.tar --stdout
real    1m5.942s
user    1m5.855s
sys     0m0.084s
++ xz -d -k xz/Seattle.valhalla.tar.xz --stdout
real    0m2.469s
user    0m2.377s
sys     0m0.084s
++ zstd -k input/Seattle.valhalla.tar --stdout
user    0m1.054s
sys     0m0.090s
++ zstd -d -k zstd/Seattle.valhalla.tar.zstd --stdout
real    0m0.329s
user    0m0.233s
sys     0m0.097s
```

</details>

<details>
<summary>
Sizes:
</summary>

```
input:
total 1.4G
-rw-r--r-- 1 mkirk mkirk 415M Dec  1 04:56 Seattle.elasticsearch.tar
-rw-r--r-- 1 mkirk mkirk 222M Dec  1 04:56 Seattle.graph.obj
-rw-r--r-- 1 mkirk mkirk  31M Dec  1 04:57 Seattle.gtfs.tar
-rw-r--r-- 1 mkirk mkirk 545M Dec  1 04:59 Seattle.placeholder.tar
-rw-r--r-- 1 mkirk mkirk 182M Dec  1 05:00 Seattle.valhalla.tar

xz:
total 393M
-rw-r--r-- 1 mkirk mkirk 199M Dec  1 04:55 Seattle.elasticsearch.tar.xz
-rw-r--r-- 1 mkirk mkirk  45M Dec  1 04:56 Seattle.graph.obj.xz
-rw-r--r-- 1 mkirk mkirk  25M Dec  1 04:57 Seattle.gtfs.tar.xz
-rw-r--r-- 1 mkirk mkirk  82M Dec  1 04:59 Seattle.placeholder.tar.xz
-rw-r--r-- 1 mkirk mkirk  44M Dec  1 05:00 Seattle.valhalla.tar.xz

zstd:
total 563M
-rw-r--r-- 1 mkirk mkirk 240M Dec  1 04:56
Seattle.elasticsearch.tar.zstd
-rw-r--r-- 1 mkirk mkirk  62M Dec  1 04:56 Seattle.graph.obj.zstd
-rw-r--r-- 1 mkirk mkirk  28M Dec  1 04:57 Seattle.gtfs.tar.zstd
-rw-r--r-- 1 mkirk mkirk 139M Dec  1 04:59 Seattle.placeholder.tar.zstd
-rw-r--r-- 1 mkirk mkirk  97M Dec  1 05:00 Seattle.valhalla.tar.zstd
```

</details>