### PR TITLE
transit timeline

### DIFF
--- a/web/frontend/src/components/MultiModalListItem.vue
+++ b/web/frontend/src/components/MultiModalListItem.vue
@@ -23,17 +23,12 @@
       v-on:click="showSteps"
     />
   </q-item-label>
-  <transit-timeline
-    :hidden="!(active && areStepsVisible)"
-    :itinerary="item"
-    :earliest-start="earliestStart"
-    :latest-arrival="latestArrival"
-  />
+  <transit-steps :hidden="!(active && areStepsVisible)" :itinerary="item" />
 </template>
 <script lang="ts">
 import Itinerary from 'src/models/Itinerary';
 import { defineComponent, PropType } from 'vue';
-import TransitTimeline from './TransitTimeline.vue';
+import TransitSteps from './TransitSteps.vue';
 
 export default defineComponent({
   name: 'MultiModalListItem',
@@ -69,8 +64,9 @@ export default defineComponent({
   methods: {
     showSteps() {
       this.areStepsVisible = true;
+      console.log(this.item);
     },
   },
-  components: { TransitTimeline },
+  components: { TransitSteps },
 });
 </script>

--- a/web/frontend/src/components/RouteListItem.vue
+++ b/web/frontend/src/components/RouteListItem.vue
@@ -1,7 +1,7 @@
 <template>
   <q-item
     class="route-list-item"
-    clickable
+    :clickable="!$props.active"
     active-class="route-list-item--selected"
     :active="$props.active"
     v-on:click="$props.clickHandler"

--- a/web/frontend/src/components/TransitSteps.vue
+++ b/web/frontend/src/components/TransitSteps.vue
@@ -1,9 +1,12 @@
 <template>
   <q-list>
     <q-item
-      class="itinerary-row"
-      v-bind:key="JSON.stringify(step)"
       v-for="step in steps"
+      v-bind:key="JSON.stringify(step)"
+      class="itinerary-row"
+      :style="step.isDestination ? 'padding-bottom: 20px;' : ''"
+      :clickable="!step.isMovement"
+      v-on:click="clickedStep(step)"
     >
       <q-item-section
         :top="step.isMovement"
@@ -109,6 +112,8 @@
 import Itinerary from 'src/models/Itinerary';
 import { defineComponent, PropType } from 'vue';
 import { formatDuration, formatTime } from 'src/utils/format';
+import { LngLat } from 'maplibre-gl';
+import { getBaseMap } from 'src/components/BaseMap.vue';
 
 export default defineComponent({
   name: 'TransitSteps',
@@ -126,6 +131,9 @@ export default defineComponent({
   methods: {
     formatTime,
     formatDuration,
+    clickedStep: (step): void => {
+      getBaseMap()?.flyTo([step.position.lng, step.position.lat], 16);
+    },
   },
 });
 
@@ -136,6 +144,7 @@ type Step = {
   description: string;
   isMovement: boolean;
   isDestination: boolean;
+  position: LngLat;
 };
 
 function buildSteps(itinerary: Itinerary): Step[] {
@@ -148,6 +157,7 @@ function buildSteps(itinerary: Itinerary): Step[] {
     description: firstLeg.sourceName,
     isMovement: false,
     isDestination: false,
+    position: firstLeg.sourceLngLat,
   };
 
   let middleSteps = itinerary.legs.flatMap((leg) => {
@@ -157,6 +167,7 @@ function buildSteps(itinerary: Itinerary): Step[] {
         timeline: '',
         timelineClasses: ['timeline-edge', `timeline-edge-${leg.mode}`],
         description: formatDuration(leg.duration),
+        position: leg.sourceLngLat,
         isMovement: true,
         isDestination: false,
       },
@@ -165,6 +176,7 @@ function buildSteps(itinerary: Itinerary): Step[] {
         timeline: '',
         timelineClasses: ['timeline-node'],
         description: leg.destinationName,
+        position: leg.destinationLngLat,
         isMovement: false,
         isDestination: false,
       },

--- a/web/frontend/src/components/TransitSteps.vue
+++ b/web/frontend/src/components/TransitSteps.vue
@@ -1,0 +1,180 @@
+<template>
+  <q-list>
+    <q-item
+      class="itinerary-row"
+      v-bind:key="JSON.stringify(step)"
+      v-for="step in steps"
+    >
+      <q-item-section
+        :top="step.isMovement"
+        class="col-3 timeline-time-mode"
+        :class="step.isDestination ? 'timeline-destination' : ''"
+        style="text-align: right; padding-right: 6px"
+        >{{ step.time }}</q-item-section
+      >
+      <q-item-section class="col-1">
+        <div
+          :class="step.timelineClasses"
+          style="text-align: center"
+          v-if="!step.isDestination"
+        >
+          {{ step.timeline }}
+        </div>
+        <div
+          :class="step.timelineClasses"
+          style="text-align: center"
+          v-if="step.isDestination"
+        >
+          <svg display="block" height="41px" width="27px" viewBox="0 0 27 41">
+            <g fill-rule="nonzero">
+              <g fill="#111111">
+                <path
+                  d="M27,13.5 C27,19.074644 20.250001,27.000002 14.75,34.500002 C14.016665,35.500004 12.983335,35.500004 12.25,34.500002 C6.7499993,27.000002 0,19.222562 0,13.5 C0,6.0441559 6.0441559,0 13.5,0 C20.955844,0 27,6.0441559 27,13.5 Z"
+                ></path>
+              </g>
+              <g transform="translate(8.0, 8.0)">
+                <circle
+                  fill="#000000"
+                  opacity="0.25"
+                  cx="5.5"
+                  cy="5.5"
+                  r="5.4999962"
+                ></circle>
+                <circle fill="#FFFFFF" cx="5.5" cy="5.5" r="5.4999962"></circle>
+              </g>
+            </g>
+          </svg>
+        </div>
+      </q-item-section>
+      <q-item-section
+        :top="step.isMovement"
+        :class="
+          ['col-8', 'timeline-description'].concat(
+            step.isDestination ? 'timeline-destination' : ''
+          )
+        "
+        >{{ step.description }}</q-item-section
+      >
+    </q-item>
+  </q-list>
+</template>
+
+<style lang="scss">
+.itinerary-row {
+  padding: 0;
+}
+
+.timeline-edge {
+  position: relative;
+  width: 100%;
+  height: calc(100% + 20px);
+  left: calc(50% - 6px);
+  margin-top: -10px;
+  margin-bottom: -10px;
+}
+
+.timeline-edge-WALK {
+  border-left: dashed $walkColor 6px;
+}
+
+.timeline-edge-BUS {
+  border-left: solid $transitColor 6px;
+}
+
+.timeline-node {
+  position: relative;
+  width: 16px;
+  height: 16px;
+  border-radius: 8px;
+  left: calc(50% - 11px);
+  border: solid #888 3px;
+}
+
+.timeline-node.timeline-origin {
+  border-color: black;
+}
+
+.timeline-node.timeline-destination {
+  border: none;
+  left: calc(50% - 15px);
+}
+
+.timeline-time-mode.timeline-destination,
+.timeline-description.timeline-destination {
+  margin-top: 26px;
+}
+</style>
+
+<script lang="ts">
+import Itinerary from 'src/models/Itinerary';
+import { defineComponent, PropType } from 'vue';
+import { formatDuration, formatTime } from 'src/utils/format';
+
+export default defineComponent({
+  name: 'TransitSteps',
+  data: function () {
+    return {
+      steps: buildSteps(this.$props.itinerary),
+    };
+  },
+  props: {
+    itinerary: {
+      type: Object as PropType<Itinerary>,
+      required: true,
+    },
+  },
+  methods: {
+    formatTime,
+    formatDuration,
+  },
+});
+
+type Step = {
+  time: string;
+  timeline: string;
+  timelineClasses: string[];
+  description: string;
+  isMovement: boolean;
+  isDestination: boolean;
+};
+
+function buildSteps(itinerary: Itinerary): Step[] {
+  const firstLeg = itinerary.legs[0];
+
+  const originStep = {
+    time: formatTime(firstLeg.startTime),
+    timeline: '',
+    timelineClasses: ['timeline-node', 'timeline-origin'],
+    description: firstLeg.sourceName,
+    isMovement: false,
+    isDestination: false,
+  };
+
+  let middleSteps = itinerary.legs.flatMap((leg) => {
+    return [
+      {
+        time: leg.shortName,
+        timeline: '',
+        timelineClasses: ['timeline-edge', `timeline-edge-${leg.mode}`],
+        description: formatDuration(leg.duration),
+        isMovement: true,
+        isDestination: false,
+      },
+      {
+        time: formatTime(leg.endTime),
+        timeline: '',
+        timelineClasses: ['timeline-node'],
+        description: leg.destinationName,
+        isMovement: false,
+        isDestination: false,
+      },
+    ];
+  });
+
+  const destinationStep = middleSteps[middleSteps.length - 1];
+  destinationStep.timelineClasses.push('timeline-destination');
+  destinationStep.isDestination = true;
+
+  return [originStep].concat(middleSteps);
+}
+</script>

--- a/web/frontend/src/css/quasar.variables.scss
+++ b/web/frontend/src/css/quasar.variables.scss
@@ -26,3 +26,7 @@ $warning: #f2c037;
 
 // components
 $separator: #ccc;
+
+// App specific UI
+$transitColor: #e21919;
+$walkColor: #1976d2;

--- a/web/frontend/src/models/Itinerary.ts
+++ b/web/frontend/src/models/Itinerary.ts
@@ -10,6 +10,7 @@ import { DistanceUnits, TravelMode } from 'src/utils/models';
 import {
   formatDistance,
   formatDuration,
+  formatTime,
   kilometersToMiles,
 } from 'src/utils/format';
 import { decodeOtpPath } from 'src/third_party/decodePath';
@@ -95,11 +96,7 @@ export default class Itinerary implements Trip {
   }
 }
 
-function formatTime(millis: number): string {
-  return new Date(millis).toLocaleTimeString([], { timeStyle: 'short' });
-}
-
-class ItineraryLeg {
+export class ItineraryLeg {
   readonly raw: OTPItineraryLeg;
   constructor(otp: OTPItineraryLeg) {
     this.raw = otp;
@@ -138,6 +135,18 @@ class ItineraryLeg {
       'line-width': this.transitLeg ? 6 : 4,
       'line-dasharray': this.transitLeg ? [1] : [1, 2],
     };
+  }
+
+  get sourceName(): string {
+    return this.raw.from.name;
+  }
+
+  get destinationName(): string {
+    return this.raw.to.name;
+  }
+
+  get duration(): number {
+    return (this.raw.endTime - this.raw.startTime) / 1000;
   }
 
   get transitLeg(): boolean {

--- a/web/frontend/src/models/Itinerary.ts
+++ b/web/frontend/src/models/Itinerary.ts
@@ -145,6 +145,14 @@ export class ItineraryLeg {
     return this.raw.to.name;
   }
 
+  get sourceLngLat(): LngLat {
+    return new LngLat(this.raw.from.lon, this.raw.from.lat);
+  }
+
+  get destinationLngLat(): LngLat {
+    return new LngLat(this.raw.to.lon, this.raw.to.lat);
+  }
+
   get duration(): number {
     return (this.raw.endTime - this.raw.startTime) / 1000;
   }

--- a/web/frontend/src/services/OTPClient.ts
+++ b/web/frontend/src/services/OTPClient.ts
@@ -18,6 +18,8 @@ export type OTPItineraryLeg = {
   transitLeg: boolean;
   legGeometry: OTPLegGeometry;
   routeShortName?: string;
+  from: { name: string };
+  to: { name: string };
 };
 
 export type OTPItinerary = {

--- a/web/frontend/src/services/OTPClient.ts
+++ b/web/frontend/src/services/OTPClient.ts
@@ -18,8 +18,8 @@ export type OTPItineraryLeg = {
   transitLeg: boolean;
   legGeometry: OTPLegGeometry;
   routeShortName?: string;
-  from: { name: string };
-  to: { name: string };
+  from: { name: string; lat: number; lon: number };
+  to: { name: string; lat: number; lon: number };
 };
 
 export type OTPItinerary = {

--- a/web/frontend/src/utils/format.ts
+++ b/web/frontend/src/utils/format.ts
@@ -62,6 +62,10 @@ export function formatDuration(
   return timeString;
 }
 
+export function formatTime(millis: number): string {
+  return new Date(millis).toLocaleTimeString([], { timeStyle: 'short' });
+}
+
 export function kilometersToMiles(kilometers: number): number {
   return kilometers * 0.62137119;
 }


### PR DESCRIPTION
For transit travel, the "details" button now shows a timeline with all the legs
of the trip, with some details about that leg.

You can click on the transfer points in the timeline to get a closer look on
the map.

There are lots of improvements that could be made, but this seemed good enough
to be useful.

https://user-images.githubusercontent.com/217057/206323120-5494b04b-3115-4cd6-a580-233e2074ad77.mp4

Note that I've removed the "water fall" transit view for now. I think that, with some work, that waterfall UI could be useful to compare a bunch of options at once, so I'd like to bring it back one day, but for now I think this improvement is more straightforward and likely to be useful in the short term. I hope to bring it back one day.
