### PR TITLE
More room for steps (and move transit steps to "steps" page, like with other modes)

### DIFF
--- a/web/frontend/src/components/BaseMap.vue
+++ b/web/frontend/src/components/BaseMap.vue
@@ -133,7 +133,7 @@ export interface BaseMapInterface {
     layer: LayerSpecification,
     beforeLayerType: string
   ) => void;
-  pushRouteLayer: (
+  pushTripLayer: (
     layerId: string,
     geometry: GeoJSON.Geometry,
     paint: LineLayerSpecification['paint']
@@ -233,7 +233,7 @@ export default defineComponent({
         return true;
       }
     },
-    pushRouteLayer(
+    pushTripLayer(
       layerId: string,
       geometry: GeoJSON.Geometry,
       paint: LineLayerSpecification['paint']
@@ -361,7 +361,7 @@ export default defineComponent({
       removeAllMarkers: this.removeAllMarkers,
       removeMarkersExcept: this.removeMarkersExcept,
       pushLayer: this.pushLayer,
-      pushRouteLayer: this.pushRouteLayer,
+      pushTripLayer: this.pushTripLayer,
       hasLayer: this.hasLayer,
       removeLayer: this.removeLayer,
       removeLayersExcept: this.removeLayersExcept,

--- a/web/frontend/src/components/MultiModalListItem.vue
+++ b/web/frontend/src/components/MultiModalListItem.vue
@@ -1,18 +1,18 @@
 <template>
   <q-item-label>
-    {{ item.startStopTimesFormatted() }}
+    {{ trip.startStopTimesFormatted() }}
   </q-item-label>
   <q-item-label caption>
-    {{ item.viaRouteFormatted }}
+    {{ trip.viaRouteFormatted }}
   </q-item-label>
   <q-item-label caption :hidden="!active">
     {{
       $t('walk_distance', {
-        preformattedDistance: item.walkingDistanceFormatted(),
+        preformattedDistance: trip.walkingDistanceFormatted(),
       })
     }}
   </q-item-label>
-  <transit-steps :hidden="!(active && areStepsVisible)" :itinerary="item" />
+  <transit-steps :hidden="!(active && areStepsVisible)" :itinerary="trip" />
 </template>
 <script lang="ts">
 import Itinerary from 'src/models/Itinerary';
@@ -22,7 +22,7 @@ import TransitSteps from './TransitSteps.vue';
 export default defineComponent({
   name: 'MultiModalListItem',
   props: {
-    item: {
+    trip: {
       type: Object as PropType<Itinerary>,
       required: true,
     },

--- a/web/frontend/src/components/MultiModalListItem.vue
+++ b/web/frontend/src/components/MultiModalListItem.vue
@@ -12,17 +12,6 @@
       })
     }}
   </q-item-label>
-  <q-item-label :hidden="active && areStepsVisible">
-    <q-btn
-      style="margin-left: -6px"
-      padding="6px"
-      flat
-      icon="directions"
-      label="Details"
-      size="sm"
-      v-on:click="showSteps"
-    />
-  </q-item-label>
   <transit-steps :hidden="!(active && areStepsVisible)" :itinerary="item" />
 </template>
 <script lang="ts">
@@ -49,10 +38,6 @@ export default defineComponent({
       type: Number,
       required: true,
     },
-    // MultiModalListItem actually doesn't use this, but SingleModeListItem needs it, so
-    // we have to include it here to avoid an "unexpected property" warning.
-    // This feels gross, but hopefully I can find a better way.
-    showRouteSteps: Function,
   },
   data(): {
     areStepsVisible: boolean;
@@ -60,12 +45,6 @@ export default defineComponent({
     return {
       areStepsVisible: false,
     };
-  },
-  methods: {
-    showSteps() {
-      this.areStepsVisible = true;
-      console.log(this.item);
-    },
   },
   components: { TransitSteps },
 });

--- a/web/frontend/src/components/MultiModalListItem.vue
+++ b/web/frontend/src/components/MultiModalListItem.vue
@@ -12,12 +12,10 @@
       })
     }}
   </q-item-label>
-  <transit-steps :hidden="!(active && areStepsVisible)" :itinerary="trip" />
 </template>
 <script lang="ts">
 import Itinerary from 'src/models/Itinerary';
 import { defineComponent, PropType } from 'vue';
-import TransitSteps from './TransitSteps.vue';
 
 export default defineComponent({
   name: 'MultiModalListItem',
@@ -39,13 +37,5 @@ export default defineComponent({
       required: true,
     },
   },
-  data(): {
-    areStepsVisible: boolean;
-  } {
-    return {
-      areStepsVisible: false,
-    };
-  },
-  components: { TransitSteps },
 });
 </script>

--- a/web/frontend/src/components/MultiModalSteps.vue
+++ b/web/frontend/src/components/MultiModalSteps.vue
@@ -75,7 +75,9 @@
   border-left: dashed $walkColor 6px;
 }
 
-.timeline-edge-BUS {
+.timeline-edge-BUS,
+.timeline-edge-TRAIN,
+.timeline-edge-TRAM {
   border-left: solid $transitColor 6px;
 }
 

--- a/web/frontend/src/components/MultiModalSteps.vue
+++ b/web/frontend/src/components/MultiModalSteps.vue
@@ -3,7 +3,6 @@
     <q-item
       v-for="step in steps"
       v-bind:key="JSON.stringify(step)"
-      class="itinerary-row"
       :style="step.isDestination ? 'padding-bottom: 20px;' : ''"
       :clickable="!step.isMovement"
       v-on:click="clickedStep(step)"
@@ -63,10 +62,6 @@
 </template>
 
 <style lang="scss">
-.itinerary-row {
-  padding: 0;
-}
-
 .timeline-edge {
   position: relative;
   width: 100%;
@@ -123,7 +118,7 @@ export default defineComponent({
     };
   },
   props: {
-    itinerary: {
+    trip: {
       type: Object as PropType<Itinerary>,
       required: true,
     },

--- a/web/frontend/src/components/MultiModalSteps.vue
+++ b/web/frontend/src/components/MultiModalSteps.vue
@@ -116,10 +116,10 @@ import { LngLat } from 'maplibre-gl';
 import { getBaseMap } from 'src/components/BaseMap.vue';
 
 export default defineComponent({
-  name: 'TransitSteps',
+  name: 'MultiModalSteps',
   data: function () {
     return {
-      steps: buildSteps(this.$props.itinerary),
+      steps: buildSteps(this.$props.trip),
     };
   },
   props: {

--- a/web/frontend/src/components/SingleModeListItem.vue
+++ b/web/frontend/src/components/SingleModeListItem.vue
@@ -2,17 +2,6 @@
   <q-item-label>
     {{ $t('via_$place', { place: item.viaRoadsFormatted }) }}
   </q-item-label>
-  <q-item-label>
-    <q-btn
-      style="margin-left: -6px"
-      padding="6px"
-      flat
-      icon="directions"
-      :label="$t('route_picker_show_route_details_btn')"
-      size="sm"
-      v-on:click="showRouteSteps(item)"
-    />
-  </q-item-label>
 </template>
 
 <script lang="ts">
@@ -22,10 +11,6 @@ import { defineComponent, PropType } from 'vue';
 export default defineComponent({
   name: 'SingleModeListItem',
   props: {
-    showRouteSteps: {
-      type: Function as PropType<(route: Route) => void>,
-      required: true,
-    },
     item: {
       type: Object as PropType<Route>,
       required: true,

--- a/web/frontend/src/components/SingleModeListItem.vue
+++ b/web/frontend/src/components/SingleModeListItem.vue
@@ -1,6 +1,6 @@
 <template>
   <q-item-label>
-    {{ $t('via_$place', { place: item.viaRoadsFormatted }) }}
+    {{ $t('via_$place', { place: trip.viaRoadsFormatted }) }}
   </q-item-label>
 </template>
 
@@ -11,7 +11,7 @@ import { defineComponent, PropType } from 'vue';
 export default defineComponent({
   name: 'SingleModeListItem',
   props: {
-    item: {
+    trip: {
       type: Object as PropType<Route>,
       required: true,
     },

--- a/web/frontend/src/components/SingleModeSteps.vue
+++ b/web/frontend/src/components/SingleModeSteps.vue
@@ -1,0 +1,42 @@
+<template>
+  <q-list>
+    <div
+      v-for="item in trip.valhallaRoute.legs[0].maneuvers"
+      v-bind:key="JSON.stringify(item)"
+    >
+      <q-item class="q-my-sm" active-class="bg-blue-1">
+        <q-item-section avatar>
+          <q-icon :name="valhallaTypeToIcon(item.type)" />
+        </q-item-section>
+        <q-item-section>
+          <q-item-label>
+            {{ item.instruction }}
+          </q-item-label>
+          <q-item-label caption>
+            {{ item.verbal_post_transition_instruction }}
+          </q-item-label>
+        </q-item-section>
+      </q-item>
+      <q-separator spaced />
+    </div>
+  </q-list>
+</template>
+
+<script lang="ts">
+import Route from 'src/models/Route';
+import { defineComponent, PropType } from 'vue';
+import { valhallaTypeToIcon } from 'src/services/ValhallaClient';
+
+export default defineComponent({
+  name: 'SingleModeSteps',
+  props: {
+    trip: {
+      type: Object as PropType<Route>,
+      required: true,
+    },
+  },
+  methods: {
+    valhallaTypeToIcon,
+  },
+});
+</script>

--- a/web/frontend/src/components/TransitSteps.vue
+++ b/web/frontend/src/components/TransitSteps.vue
@@ -131,7 +131,7 @@ export default defineComponent({
   methods: {
     formatTime,
     formatDuration,
-    clickedStep: (step): void => {
+    clickedStep: (step: Step): void => {
       getBaseMap()?.flyTo([step.position.lng, step.position.lat], 16);
     },
   },

--- a/web/frontend/src/components/TripListItem.vue
+++ b/web/frontend/src/components/TripListItem.vue
@@ -1,8 +1,8 @@
 <template>
   <q-item
-    class="route-list-item"
+    class="trip-list-item"
     :clickable="!$props.active"
-    active-class="route-list-item--selected"
+    active-class="trip-list-item--selected"
     :active="$props.active"
     v-on:click="$props.clickHandler"
   >
@@ -20,11 +20,23 @@
   </q-item>
 </template>
 
+<style lang="scss">
+.trip-list-item {
+  border-bottom: solid $separator 1px;
+  padding: 16px;
+}
+
+.trip-list-item--selected {
+  border-left: solid $accent 8px;
+  padding-left: 8px;
+}
+</style>
+
 <script lang="ts">
 import { defineComponent } from 'vue';
 
 export default defineComponent({
-  name: 'RouteListItem',
+  name: 'TripListItem',
   props: {
     active: Boolean,
     clickHandler: Function,

--- a/web/frontend/src/css/app.scss
+++ b/web/frontend/src/css/app.scss
@@ -207,13 +207,3 @@ html {
 body {
   height: 100%;
 }
-
-.route-list-item {
-  border-bottom: solid $separator 1px;
-  padding: 16px;
-}
-
-.route-list-item--selected {
-  border-left: solid $accent 8px;
-  padding-left: 8px;
-}

--- a/web/frontend/src/pages/AlternatesPage.vue
+++ b/web/frontend/src/pages/AlternatesPage.vue
@@ -20,11 +20,21 @@
         <component
           :is="componentForMode(item.mode)"
           :item="item"
-          :showRouteSteps="showRouteSteps"
           :active="item === activeRoute"
           :earliest-start="earliestStart"
           :latest-arrival="latestArrival"
         />
+        <q-item-label>
+          <q-btn
+            style="margin-left: -6px"
+            padding="6px"
+            flat
+            icon="directions"
+            :label="$t('route_picker_show_route_details_btn')"
+            size="sm"
+            v-on:click="showTripSteps(item)"
+          />
+        </q-item-label>
       </route-list-item>
     </q-list>
   </div>
@@ -111,11 +121,7 @@ export default defineComponent({
       this.toPoi = poi;
       this.rewriteUrl();
     },
-    showRouteSteps(route: Route) {
-      console.assert(
-        this.mode != TravelMode.Transit,
-        'show route steps should only be availble for non-transit'
-      );
+    showTripSteps(route: Route) {
       let index = this.$data.routes.indexOf(route);
       if (index !== -1 && this.to && this.from) {
         this.$router.push(

--- a/web/frontend/src/pages/AlternatesPage.vue
+++ b/web/frontend/src/pages/AlternatesPage.vue
@@ -9,18 +9,18 @@
   />
   <div class="bottom-card bg-white" ref="bottomCard" v-if="fromPoi && toPoi">
     <q-list>
-      <route-list-item
-        v-for="item in $data.routes"
-        :click-handler="() => clickRoute(item)"
-        :active="$data.activeRoute === item"
-        :duration-formatted="item.durationFormatted"
-        :distance-formatted="item.lengthFormatted"
-        v-bind:key="JSON.stringify(item)"
+      <trip-list-item
+        v-for="trip in $data.trips"
+        :click-handler="() => clickTrip(trip)"
+        :active="$data.activeTrip === trip"
+        :duration-formatted="trip.durationFormatted"
+        :distance-formatted="trip.lengthFormatted"
+        v-bind:key="JSON.stringify(trip)"
       >
         <component
-          :is="componentForMode(item.mode)"
-          :item="item"
-          :active="item === activeRoute"
+          :is="componentForMode(trip.mode)"
+          :trip="trip"
+          :active="trip === activeTrip"
           :earliest-start="earliestStart"
           :latest-arrival="latestArrival"
         />
@@ -32,10 +32,10 @@
             icon="directions"
             :label="$t('route_picker_show_route_details_btn')"
             size="sm"
-            v-on:click="showTripSteps(item)"
+            v-on:click="showTripSteps(trip)"
           />
         </q-item-label>
-      </route-list-item>
+      </trip-list-item>
     </q-list>
   </div>
 </template>
@@ -55,10 +55,9 @@ import {
   poiDisplayName,
 } from 'src/utils/models';
 import { Component, defineComponent, Ref, ref } from 'vue';
-import Route from 'src/models/Route';
 import Place from 'src/models/Place';
 import { TravelMode } from 'src/utils/models';
-import RouteListItem from 'src/components/RouteListItem.vue';
+import TripListItem from 'src/components/TripListItem.vue';
 import TripSearch from 'src/components/TripSearch.vue';
 import SingleModeListItem from 'src/components/SingleModeListItem.vue';
 import MultiModalListItem from 'src/components/MultiModalListItem.vue';
@@ -80,20 +79,20 @@ export default defineComponent({
     from: String,
   },
   data: function (): {
-    routes: Trip[];
-    activeRoute: Trip | undefined;
+    trips: Trip[];
+    activeTrip: Trip | undefined;
     // only used by transit
     earliestStart: number;
     latestArrival: number;
   } {
     return {
-      routes: [],
-      activeRoute: undefined,
+      trips: [],
+      activeTrip: undefined,
       earliestStart: 0,
       latestArrival: 0,
     };
   },
-  components: { RouteListItem, TripSearch },
+  components: { TripListItem, TripSearch },
   methods: {
     componentForMode(mode: TravelMode): Component {
       switch (mode) {
@@ -106,11 +105,11 @@ export default defineComponent({
       }
     },
     poiDisplayName,
-    clickRoute(route: Trip) {
-      this.$data.activeRoute = route;
-      let index = this.$data.routes.indexOf(route);
+    clickTrip(trip: Trip) {
+      this.$data.activeTrip = trip;
+      let index = this.$data.trips.indexOf(trip);
       if (index !== -1) {
-        this.renderRoutes(this.$data.routes, index);
+        this.renderTrips(this.$data.trips, index);
       }
     },
     searchBoxDidSelectFromPoi(poi?: POI) {
@@ -121,8 +120,8 @@ export default defineComponent({
       this.toPoi = poi;
       this.rewriteUrl();
     },
-    showTripSteps(route: Route) {
-      let index = this.$data.routes.indexOf(route);
+    showTripSteps(trip: Trip) {
+      let index = this.$data.trips.indexOf(trip);
       if (index !== -1 && this.to && this.from) {
         this.$router.push(
           `/directions/${this.mode}/${encodeURIComponent(
@@ -154,34 +153,34 @@ export default defineComponent({
           '/' +
           encodeURIComponent(fromCanonical)
       );
-      await this.updateRoutes();
+      await this.updateTrips();
     },
 
-    async updateRoutes(): Promise<void> {
+    async updateTrips(): Promise<void> {
       getBaseMap()?.removeAllLayers();
       getBaseMap()?.removeAllMarkers();
       if (fromPoi.value?.position && toPoi.value?.position) {
         const fromCanonical = canonicalizePoi(fromPoi.value);
         // TODO: replace POI with Place so we don't have to hit pelias twice?
         let fromPlace = await Place.fetchFromSerializedId(fromCanonical);
-        const routes = await fetchBestTrips(
+        const trips = await fetchBestTrips(
           toLngLat(fromPoi.value.position),
           toLngLat(toPoi.value.position),
           this.mode,
           fromPlace.preferredDistanceUnits() ?? DistanceUnits.Kilometers
         );
-        this.calculateTransitStats(routes);
-        this.renderRoutes(routes, 0);
+        this.calculateTransitStats(trips);
+        this.renderTrips(trips, 0);
       }
     },
-    renderRoutes(routes: Trip[], selectedIdx: number) {
+    renderTrips(trips: Trip[], selectedIdx: number) {
       const map = getBaseMap();
       if (!map) {
         console.error('basemap was unexpectedly empty');
         return;
       }
-      this.$data.routes = routes;
-      this.activeRoute = routes[selectedIdx];
+      this.$data.trips = trips;
+      this.activeTrip = trips[selectedIdx];
 
       if (fromPoi.value?.position) {
         map.pushMarker(
@@ -202,44 +201,44 @@ export default defineComponent({
         );
       }
 
-      const unselectedLayerName = (routeIdx: number, legIdx: number) =>
-        `aleternate_${this.mode}_${routeIdx}.${legIdx}_unselected`;
-      const selectedLayerName = (routeIdx: number, legIdx: number) =>
-        `aleternate_${this.mode}_${routeIdx}.${legIdx}_selected`;
+      const unselectedLayerName = (tripIdx: number, legIdx: number) =>
+        `aleternate_${this.mode}_${tripIdx}.${legIdx}_unselected`;
+      const selectedLayerName = (tripIdx: number, legIdx: number) =>
+        `aleternate_${this.mode}_${tripIdx}.${legIdx}_selected`;
 
-      for (let routeIdx = 0; routeIdx < routes.length; routeIdx++) {
-        const route = routes[routeIdx];
-        for (let legIdx = 0; legIdx < route.legs.length; legIdx++) {
-          const leg = route.legs[legIdx];
-          if (routeIdx == selectedIdx) {
-            if (map.hasLayer(unselectedLayerName(routeIdx, legIdx))) {
-              map.removeLayer(unselectedLayerName(routeIdx, legIdx));
+      for (let tripIdx = 0; tripIdx < trips.length; tripIdx++) {
+        const trip = trips[tripIdx];
+        for (let legIdx = 0; legIdx < trip.legs.length; legIdx++) {
+          const leg = trip.legs[legIdx];
+          if (tripIdx == selectedIdx) {
+            if (map.hasLayer(unselectedLayerName(tripIdx, legIdx))) {
+              map.removeLayer(unselectedLayerName(tripIdx, legIdx));
             }
             continue;
           }
 
-          if (map.hasLayer(selectedLayerName(routeIdx, legIdx))) {
-            map.removeLayer(selectedLayerName(routeIdx, legIdx));
+          if (map.hasLayer(selectedLayerName(tripIdx, legIdx))) {
+            map.removeLayer(selectedLayerName(tripIdx, legIdx));
           }
 
-          if (map.hasLayer(unselectedLayerName(routeIdx, legIdx))) {
+          if (map.hasLayer(unselectedLayerName(tripIdx, legIdx))) {
             continue;
           }
 
-          map.pushRouteLayer(
-            unselectedLayerName(routeIdx, legIdx),
+          map.pushTripLayer(
+            unselectedLayerName(tripIdx, legIdx),
             leg.geometry(),
             leg.paintStyle(false)
           );
         }
       }
 
-      // Add selected route last to be sure it's on top of the unselected routes
-      const selectedRoute = routes[selectedIdx];
-      for (let legIdx = 0; legIdx < selectedRoute.legs.length; legIdx++) {
-        const leg = selectedRoute.legs[legIdx];
+      // Add selected trip last to be sure it's on top of the unselected trips
+      const selectedTrip = trips[selectedIdx];
+      for (let legIdx = 0; legIdx < selectedTrip.legs.length; legIdx++) {
+        const leg = selectedTrip.legs[legIdx];
         if (!map.hasLayer(selectedLayerName(selectedIdx, legIdx))) {
-          map.pushRouteLayer(
+          map.pushTripLayer(
             selectedLayerName(selectedIdx, legIdx),
             leg.geometry(),
             leg.paintStyle(true)
@@ -249,7 +248,7 @@ export default defineComponent({
       setTimeout(async () => {
         this.resizeMap();
       });
-      getBaseMap()?.fitBounds(selectedRoute.bounds);
+      getBaseMap()?.fitBounds(selectedTrip.bounds);
     },
     resizeMap() {
       if (this.$refs.bottomCard && this.$refs.bottomCard) {
@@ -260,7 +259,7 @@ export default defineComponent({
         setBottomCardAllowance(0);
       }
     },
-    calculateTransitStats(routes: Trip[]) {
+    calculateTransitStats(trips: Trip[]) {
       this.$data.earliestStart = Number.MAX_SAFE_INTEGER;
       this.$data.latestArrival = 0;
       // terrible hack.
@@ -268,7 +267,7 @@ export default defineComponent({
         return;
       }
 
-      let itineraries: Itinerary[] = routes as Itinerary[];
+      let itineraries: Itinerary[] = trips as Itinerary[];
 
       for (var index = 0; index < itineraries.length; index++) {
         this.$data.earliestStart = Math.min(
@@ -284,7 +283,7 @@ export default defineComponent({
   },
   watch: {
     mode: async function (): Promise<void> {
-      await this.updateRoutes();
+      await this.updateTrips();
       this.resizeMap();
     },
   },

--- a/web/frontend/src/pages/AlternatesPage.vue
+++ b/web/frontend/src/pages/AlternatesPage.vue
@@ -202,9 +202,9 @@ export default defineComponent({
       }
 
       const unselectedLayerName = (tripIdx: number, legIdx: number) =>
-        `aleternate_${this.mode}_${tripIdx}.${legIdx}_unselected`;
+        `alternate_${this.mode}_${tripIdx}.${legIdx}_unselected`;
       const selectedLayerName = (tripIdx: number, legIdx: number) =>
-        `aleternate_${this.mode}_${tripIdx}.${legIdx}_selected`;
+        `alternate_${this.mode}_${tripIdx}.${legIdx}_selected`;
 
       for (let tripIdx = 0; tripIdx < trips.length; tripIdx++) {
         const trip = trips[tripIdx];

--- a/web/frontend/src/pages/StepsPage.vue
+++ b/web/frontend/src/pages/StepsPage.vue
@@ -6,10 +6,20 @@
     class="top-left-fab"
     v-on:click="() => onBackClicked()"
   />
-  <div class="bottom-card bg-white" ref="bottomCard" v-if="fromPoi && toPoi">
+  <div
+    class="bottom-card steps-page-bottom-card bg-white"
+    ref="bottomCard"
+    v-if="fromPoi && toPoi"
+  >
     <component v-if="trip" :is="componentForMode(trip.mode)" :trip="trip" />
   </div>
 </template>
+
+<style lang="scss">
+.steps-page-bottom-card {
+  max-height: 80%;
+}
+</style>
 
 <script lang="ts">
 import { getBaseMap, setBottomCardAllowance } from 'src/components/BaseMap.vue';

--- a/web/frontend/src/pages/StepsPage.vue
+++ b/web/frontend/src/pages/StepsPage.vue
@@ -17,7 +17,7 @@
 
 <style lang="scss">
 .steps-page-bottom-card {
-  max-height: 80%;
+  max-height: calc(100% - 200px);
 }
 </style>
 

--- a/web/frontend/src/pages/StepsPage.vue
+++ b/web/frontend/src/pages/StepsPage.vue
@@ -152,13 +152,15 @@ export default defineComponent({
       map.fitBounds(trip.bounds);
     },
     resizeMap() {
-      if (this.$refs.bottomCard && this.$refs.bottomCard) {
-        setBottomCardAllowance(
-          (this.$refs.bottomCard as HTMLDivElement).offsetHeight
-        );
-      } else {
+      if (!this.$refs.bottomCard) {
+        console.error('bottom card was missing');
         setBottomCardAllowance(0);
+        return;
       }
+
+      setBottomCardAllowance(
+        (this.$refs.bottomCard as HTMLDivElement).offsetHeight
+      );
     },
   },
   mounted: async function () {

--- a/web/frontend/src/pages/StepsPage.vue
+++ b/web/frontend/src/pages/StepsPage.vue
@@ -7,51 +7,28 @@
     v-on:click="() => onBackClicked()"
   />
   <div class="bottom-card bg-white" ref="bottomCard" v-if="fromPoi && toPoi">
-    <q-list>
-      <div v-for="item in $data.steps" v-bind:key="JSON.stringify(item)">
-        <q-item class="q-my-sm" active-class="bg-blue-1">
-          <q-item-section avatar>
-            <q-icon :name="valhallaTypeToIcon(item.type)" />
-          </q-item-section>
-          <q-item-section>
-            <q-item-label>
-              {{ item.instruction }}
-            </q-item-label>
-            <q-item-label caption>
-              {{ item.verbal_post_transition_instruction }}
-            </q-item-label>
-          </q-item-section>
-        </q-item>
-        <q-separator spaced />
-      </div>
-    </q-list>
+    <component v-if="trip" :is="componentForMode(trip.mode)" :trip="trip" />
   </div>
 </template>
 
 <script lang="ts">
-import {
-  getBaseMap,
-  map,
-  setBottomCardAllowance,
-} from 'src/components/BaseMap.vue';
+import { getBaseMap, setBottomCardAllowance } from 'src/components/BaseMap.vue';
 import {
   encodePoi,
   canonicalizePoi,
   decanonicalizePoi,
   POI,
   poiDisplayName,
+  TravelMode,
+  DistanceUnits,
 } from 'src/utils/models';
 import Place from 'src/models/Place';
-import Route from 'src/models/Route';
-import { defineComponent, Ref, ref } from 'vue';
-import { decodeValhallaPath } from 'src/third_party/decodePath';
-import { LngLat, LngLatBounds, Marker } from 'maplibre-gl';
-import {
-  ValhallaRouteLegManeuver,
-  CacheableMode,
-  valhallaTypeToIcon,
-} from 'src/services/ValhallaClient';
+import { defineComponent, Component, Ref, ref } from 'vue';
+import { Marker } from 'maplibre-gl';
 import { toLngLat } from 'src/utils/geomath';
+import Trip, { fetchBestTrips } from 'src/models/Trip';
+import SingleModeSteps from 'src/components/SingleModeSteps.vue';
+import MultiModalSteps from 'src/components/MultiModalSteps.vue';
 
 var toPoi: Ref<POI | undefined> = ref(undefined);
 var fromPoi: Ref<POI | undefined> = ref(undefined);
@@ -59,21 +36,43 @@ var fromPoi: Ref<POI | undefined> = ref(undefined);
 export default defineComponent({
   name: 'StepsPage',
   props: {
-    mode: String,
-    to: String,
-    from: String,
-    alternateIndex: String,
+    mode: {
+      type: String as () => TravelMode,
+      required: true,
+    },
+    to: {
+      type: String,
+      required: true,
+    },
+    from: {
+      type: String,
+      required: true,
+    },
+    alternateIndex: {
+      type: String,
+      required: true,
+    },
   },
   data: function (): {
-    steps: ValhallaRouteLegManeuver[];
+    trip?: Trip;
   } {
     return {
-      steps: [],
+      trip: undefined,
     };
   },
   methods: {
     poiDisplayName,
-    valhallaTypeToIcon,
+    componentForMode(mode: TravelMode): Component {
+      switch (mode) {
+        case TravelMode.Walk:
+        case TravelMode.Bike:
+        case TravelMode.Drive:
+          return SingleModeSteps;
+        case TravelMode.Transit:
+          return MultiModalSteps;
+      }
+    },
+
     onBackClicked() {
       if (!fromPoi.value?.position && !toPoi.value?.position) {
         this.$router.push('/');
@@ -86,6 +85,12 @@ export default defineComponent({
       );
     },
     rewriteUrl: async function () {
+      let map = getBaseMap();
+      if (!map) {
+        console.error('map was not set');
+        return;
+      }
+
       if (!fromPoi.value?.position && !toPoi.value?.position) {
         this.$router.push('/');
         return;
@@ -102,82 +107,39 @@ export default defineComponent({
       if (fromPoi.value?.position && toPoi.value?.position) {
         // TODO: replace POI with Place so we don't have to hit pelias twice?
         let fromPlace = await Place.fetchFromSerializedId(fromCanonical);
-        const routes = await Route.getRoutes(
+        const trips = await fetchBestTrips(
           toLngLat(fromPoi.value.position),
           toLngLat(toPoi.value.position),
-          this.mode as CacheableMode,
-          fromPlace.preferredDistanceUnits()
+          this.mode,
+          fromPlace.preferredDistanceUnits() ?? DistanceUnits.Kilometers
         );
-        if (this.alternateIndex) {
-          let idx = parseInt(this.alternateIndex);
-          this.processRoute(routes, idx);
-        }
-      } else {
-        if (map?.getLayer('headway_polyline')) {
-          map?.removeLayer('headway_polyline');
-        }
-        if (map?.getSource('headway_polyline')) {
-          map?.removeSource('headway_polyline');
-        }
+        let idx = parseInt(this.alternateIndex);
+        let trip = trips[idx];
+        console.assert(trip);
+        this.$data.trip = trip;
+        this.renderTripLayer(trip);
       }
     },
-    processRoute(routes: Route[], selectedIdx: number) {
-      for (var i = 0; i < 10; i += 1) {
-        if (map?.getLayer('headway_polyline' + i)) {
-          map?.removeLayer('headway_polyline' + i);
-        }
-        if (map?.getSource('headway_polyline' + i)) {
-          map?.removeSource('headway_polyline' + i);
-        }
+    renderTripLayer(trip: Trip) {
+      let map = getBaseMap();
+      if (!map) {
+        console.error('map was not set');
+        return;
       }
-      const route = routes[selectedIdx];
-      const leg = route.valhallaRoute.legs[0];
-      this.$data.steps = leg.maneuvers;
-      if (leg && map) {
-        var totalTime = 0;
-        for (const key in leg.maneuvers) {
-          totalTime += leg.maneuvers[key].time;
-          leg.maneuvers[key].time = totalTime;
-        }
-        var points: [number, number][] = [];
-        decodeValhallaPath(leg.shape, 6).forEach((point) => {
-          points.push([point[1], point[0]]);
-        });
-        getBaseMap()?.pushTripLayer(
-          'headway_polyline' + selectedIdx,
-          // currently valhalla routes only ever have 1 leg.
-          route.legs[0].geometry(),
-          {
-            'line-color': '#1976D2',
-            'line-width': 6,
-          }
+
+      // TODO: add a map.filterLayers((layerName: string) => boolean) method so
+      // we can keep the layer we need and remove the others based on a prefix/regex/w.e.
+      map.removeAllLayers();
+
+      for (let legIdx = 0; legIdx < trip.legs.length; legIdx++) {
+        const leg = trip.legs[legIdx];
+        map.pushTripLayer(
+          `selected_trip_leg_${legIdx}`,
+          leg.geometry(),
+          leg.paintStyle(true)
         );
-        setTimeout(() => {
-          this.resizeMap();
-          getBaseMap()?.fitBounds(
-            new LngLatBounds(
-              new LngLat(
-                route.valhallaRoute.summary.min_lon,
-                route.valhallaRoute.summary.min_lat
-              ),
-              new LngLat(
-                route.valhallaRoute.summary.max_lon,
-                route.valhallaRoute.summary.max_lat
-              )
-            )
-          );
-        });
       }
-    },
-    clearPolylines() {
-      for (var i = 0; i < 10; i += 1) {
-        if (map?.getLayer('headway_polyline' + i)) {
-          map?.removeLayer('headway_polyline' + i);
-        }
-        if (map?.getSource('headway_polyline' + i)) {
-          map?.removeSource('headway_polyline' + i);
-        }
-      }
+      map.fitBounds(trip.bounds);
     },
     resizeMap() {
       if (this.$refs.bottomCard && this.$refs.bottomCard) {
@@ -189,48 +151,20 @@ export default defineComponent({
       }
     },
   },
-  watch: {
-    to(newValue) {
-      setTimeout(async () => {
-        toPoi.value = await decanonicalizePoi(newValue);
-        if (!toPoi.value) {
-          this.clearPolylines();
-        }
-        this.resizeMap();
-
-        getBaseMap()?.removeMarkersExcept([]);
-
-        if (!newValue.position) {
-          return;
-        }
-        const marker = new Marker({ color: '#111111' }).setLngLat([
-          newValue.position.long,
-          newValue.position.lat,
-        ]);
-        getBaseMap()?.pushMarker('active_marker', marker);
-      });
-    },
-    from(newValue) {
-      setTimeout(async () => {
-        fromPoi.value = await decanonicalizePoi(newValue);
-        if (!fromPoi.value) {
-          this.clearPolylines();
-        }
-        this.resizeMap();
-      });
-    },
-  },
-  beforeUnmount: function () {
-    this.clearPolylines();
-  },
   mounted: async function () {
     setTimeout(async () => {
+      let map = getBaseMap();
+      if (!map) {
+        console.error('map was not set');
+        return;
+      }
+
       toPoi.value = await decanonicalizePoi(this.$props.to as string);
       fromPoi.value = await decanonicalizePoi(this.$props.from as string);
       await this.rewriteUrl();
       this.resizeMap();
 
-      getBaseMap()?.removeMarkersExcept([]);
+      getBaseMap()?.removeAllMarkers();
       if (this.toPoi?.position) {
         const marker = new Marker({ color: '#111111' }).setLngLat([
           this.toPoi.position.long,
@@ -239,14 +173,6 @@ export default defineComponent({
         getBaseMap()?.pushMarker('active_marker', marker);
       }
     });
-  },
-  unmounted: function () {
-    if (map?.getLayer('headway_polyline')) {
-      map?.removeLayer('headway_polyline');
-    }
-    if (map?.getSource('headway_polyline')) {
-      map?.removeSource('headway_polyline');
-    }
   },
   setup: function () {
     return {

--- a/web/frontend/src/pages/StepsPage.vue
+++ b/web/frontend/src/pages/StepsPage.vue
@@ -143,7 +143,7 @@ export default defineComponent({
         decodeValhallaPath(leg.shape, 6).forEach((point) => {
           points.push([point[1], point[0]]);
         });
-        getBaseMap()?.pushRouteLayer(
+        getBaseMap()?.pushTripLayer(
           'headway_polyline' + selectedIdx,
           // currently valhalla routes only ever have 1 leg.
           route.legs[0].geometry(),


### PR DESCRIPTION
**before (single mode)**

Previously (and unchanged in this PR), the "details" button for single-mode would take you to a "steps" page.

<img width="392" alt="Screenshot 2022-12-08 at 2 33 32 PM" src="https://user-images.githubusercontent.com/217057/206581577-780bfa65-cfb7-4332-8796-d66aacee5427.png">

**before (multimodal)**

But for multimodal, it would render the transit timeline in-line on the Alternates page. There wasn't much room to show you the various steps without scrolling a bunch.
<img width="522" alt="Screenshot 2022-12-08 at 2 34 51 PM" src="https://user-images.githubusercontent.com/217057/206581566-427c106c-8cc6-4c26-af21-3e2f4f93890a.png">

**after (multimodal)**

Now the details button takes you to the "steps"  page for multimodal too, and I've increased the max-height available to the bottom card on that screen.

<img width="401" alt="Screenshot 2022-12-08 at 2 49 10 PM" src="https://user-images.githubusercontent.com/217057/206583700-758cc333-7a00-4c25-91c5-3a4ba99c4aab.png">

**after (single mode)**

<img width="407" alt="Screenshot 2022-12-08 at 2 49 20 PM" src="https://user-images.githubusercontent.com/217057/206583695-332b995e-930a-49ca-9fa5-b5e7278bc9ac.png">

Overall I think it's a small improvement, but I think there's some other easier things that can now be done to improve the steps screen, like...

- show the trip overview (from/to/duration)
- click on individual steps for the Routes (valhalla) to zoom to that step. We already do this for the multimodal Itineraries (otp).
- on mobile, I'd like to have all the steps in a sheet UI so that the user can reveal more of the map if they'd like, but I don't know how easy that'd be on web.
