### PR TITLE
FIX: (mobile) selecting item from autocomplete requires two taps

### DIFF
--- a/web/frontend/src/components/SearchBox.vue
+++ b/web/frontend/src/components/SearchBox.vue
@@ -11,17 +11,16 @@
       :debounce="0"
       :dense="true"
       v-on:clear="() => selectPoi(undefined)"
-      v-on:blur="deferHide(castToMenu($refs.autoCompleteMenu))"
+      v-on:blur="deferHide(autoCompleteMenu())"
       v-on:beforeinput="
-        (event) =>
-          updateAutocompleteEventBeforeInput(
-            event,
-            castToMenu($refs.autoCompleteMenu)
-          )
+  (event: Event) =>
+    updateAutocompleteEventBeforeInput(
+      event,
+      autoCompleteMenu()
+      )
       "
       v-on:update:model-value="
-        () =>
-          updateAutocompleteEventRawString(castToMenu($refs.autoCompleteMenu))
+        () => updateAutocompleteEventRawString(autoCompleteMenu())
       "
     >
     </q-input>
@@ -31,25 +30,27 @@
       :no-focus="true"
       :no-refocus="true"
       v-on:before-hide="removeHoverMarkers"
-      :target="castToTarget($refs.autoCompleteInput)"
+      :target="($refs.autoCompleteInput as Element)"
     >
-      <q-item
-        :key="item?.key"
-        v-for="item in autocompleteOptions"
-        clickable
-        v-on:click="() => selectPoi(item)"
-        v-on:mouseenter="() => hoverPoi(item)"
-        v-on:mouseleave="() => hoverPoi(undefined)"
-      >
-        <q-item-section>
-          <q-item-label>{{
-            item?.name ? item.name : item?.address
-          }}</q-item-label>
-          <q-item-label v-if="item?.name" caption>{{
-            item.address
-          }}</q-item-label>
-        </q-item-section>
-      </q-item>
+      <q-list>
+        <q-item
+          :key="item?.key"
+          v-for="item in autocompleteOptions"
+          clickable
+          v-on:click="selectPoi(item)"
+          v-on:mouseenter="hoverPoi(item)"
+          v-on:mouseleave="hoverPoi(undefined)"
+        >
+          <q-item-section>
+            <q-item-label>{{
+              item?.name ? item.name : item?.address
+            }}</q-item-label>
+            <q-item-label v-if="item?.name" caption>{{
+              item.address
+            }}</q-item-label>
+          </q-item-section>
+        </q-item>
+      </q-list>
     </q-menu>
   </div>
 </template>
@@ -71,7 +72,11 @@ export default defineComponent({
     forceText: String,
     hint: String,
   },
-  methods: {},
+  methods: {
+    autoCompleteMenu(): QMenu {
+      return this.$refs.autoCompleteMenu as QMenu;
+    },
+  },
   watch: {
     forceText: {
       immediate: true,
@@ -160,14 +165,6 @@ export default defineComponent({
       inputText,
       autocompleteOptions,
       poiHovered,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      castToTarget(target: any) {
-        return target as Element;
-      },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      castToMenu(menu: any) {
-        return menu as QMenu;
-      },
       deferHide(menu: QMenu) {
         setTimeout(() => {
           menu.hide();

--- a/web/frontend/src/components/SearchBox.vue
+++ b/web/frontend/src/components/SearchBox.vue
@@ -211,6 +211,16 @@ export default defineComponent({
         });
       },
       hoverPoi(poi: POI | undefined) {
+        if (!supportsHover()) {
+          // FIX: selecting automcomplete item on mobile requires double
+          // tapping.
+          //
+          // On touch devices, where hover is not supported, this method is
+          // fired upon tapping. I don't fully understand why, but maybe
+          // mutating the state in this method would rebuild the component,
+          // canceling any outstanding event handlers on the old component.
+          return;
+        }
         poiHovered.value = poi;
 
         if (hoverMarker) {
@@ -232,4 +242,8 @@ export default defineComponent({
     };
   },
 });
+
+function supportsHover(): boolean {
+  return window.matchMedia('(hover: hover)').matches;
+}
 </script>


### PR DESCRIPTION
On mobile (iOS), I had to tap twice in order to select an item from the autocomplete list. 

Looking into it a bit, it's because when tapping, just before the "click" event was fired, a "mouseover" event was also fired, which mutated the component state. I suspect this caused the component to be recreated and maybe canceled the pending "click" event, but that part's speculation. 

If anyone who has an Android device is paying attention to these PR's, it'd be nice to know if this works for you:
1. go to https://seattle.maps.earth (the fix isn't deployed yet to the planet instance)
1. Start to type the name of a place into the search bar
2. See the autocomplete menu populated with results
3. Tap (just once!) on an item in the list, and verify you are taken to the "place" page for the selected point.
