### PR TITLE
Show useful error when trying to route to an unsupported area

### DIFF
--- a/web/frontend/src/i18n/en-US/index.ts
+++ b/web/frontend/src/i18n/en-US/index.ts
@@ -1,4 +1,11 @@
 export default {
+  transit_area_not_supported_for_source:
+    'Sorry, trips starting here are outside of our current transit coverage area.',
+  transit_area_not_supported_for_destination:
+    'Sorry, this destination is outside of our current transit coverage area.',
+  transit_trip_error_unknown:
+    'Sorry, unable to find transit directions for this trip.',
+  try_driving_directions: 'Try driving directions instead?',
   where_to_question: 'Where to?',
   my_location: 'My Location',
   could_not_get_gps_location: 'Could not get GPS location',

--- a/web/frontend/src/i18n/en-US/index.ts
+++ b/web/frontend/src/i18n/en-US/index.ts
@@ -1,4 +1,6 @@
 export default {
+  routing_area_not_supported:
+    'Sorry, directions are not supported for this trip area.',
   transit_area_not_supported_for_source:
     'Sorry, trips starting here are outside of our current transit coverage area.',
   transit_area_not_supported_for_destination:

--- a/web/frontend/src/models/Trip.ts
+++ b/web/frontend/src/models/Trip.ts
@@ -1,6 +1,7 @@
 import { LineLayerSpecification, LngLat, LngLatBounds } from 'maplibre-gl';
 import { DistanceUnits, TravelMode } from 'src/utils/models';
-import Itinerary from './Itinerary';
+import { Err, Ok, Result } from 'src/utils/Result';
+import Itinerary, { ItineraryError } from './Itinerary';
 import Route from './Route';
 
 export default interface Trip {
@@ -16,20 +17,28 @@ export interface TripLeg {
   paintStyle(active: boolean): LineLayerSpecification['paint'];
 }
 
+export type TripFetchError = { itineraryError: ItineraryError };
+
 export async function fetchBestTrips(
   from: LngLat,
   to: LngLat,
   mode: TravelMode,
   distanceUnits: DistanceUnits
-): Promise<Trip[]> {
+): Promise<Result<Trip[], TripFetchError>> {
   switch (mode) {
     case TravelMode.Walk:
     case TravelMode.Bike:
     case TravelMode.Drive: {
-      return Route.getRoutes(from, to, mode, distanceUnits);
+      return Ok(await Route.getRoutes(from, to, mode, distanceUnits));
     }
     case TravelMode.Transit: {
-      return Itinerary.fetchBest(from, to, distanceUnits);
+      const result = await Itinerary.fetchBest(from, to, distanceUnits);
+      if (result.ok) {
+        return Ok(result.value);
+      } else {
+        const itineraryError = result.error;
+        return Err({ itineraryError });
+      }
     }
   }
 }

--- a/web/frontend/src/pages/StepsPage.vue
+++ b/web/frontend/src/pages/StepsPage.vue
@@ -4,7 +4,7 @@
     round
     icon="arrow_back"
     class="top-left-fab"
-    v-on:click="() => onBackClicked()"
+    v-on:click="() => goToAlternates()"
   />
   <div class="bottom-card steps-page-bottom-card bg-white" ref="bottomCard">
     <component v-if="trip" :is="componentForMode(trip.mode)" :trip="trip" />
@@ -73,7 +73,7 @@ export default defineComponent({
       }
     },
 
-    onBackClicked() {
+    goToAlternates() {
       const fromEncoded = fromPlace.value?.urlEncodedId() ?? '_';
       const toEncoded = toPlace.value?.urlEncodedId() ?? '_';
       this.$router.push(`/directions/${this.mode}/${toEncoded}/${fromEncoded}`);
@@ -93,12 +93,19 @@ export default defineComponent({
       );
 
       if (fromPlace.value && toPlace.value) {
-        const trips = await fetchBestTrips(
+        const result = await fetchBestTrips(
           fromPlace.value.point,
           toPlace.value.point,
           this.mode,
           fromPlace.value.preferredDistanceUnits() ?? DistanceUnits.Kilometers
         );
+        if (!result.ok) {
+          console.error('fetchBestTrips.error', result.error);
+          this.goToAlternates();
+          return;
+        }
+
+        let trips = result.value;
         let idx = parseInt(this.alternateIndex);
         const trip = trips[idx];
         console.assert(trip);

--- a/web/frontend/src/router/routes.ts
+++ b/web/frontend/src/router/routes.ts
@@ -40,6 +40,7 @@ const routes: RouteRecordRaw[] = [
     component: () => import('layouts/MainLayout.vue'),
     children: [
       {
+        name: 'alternates',
         path: '/directions/:mode/:to/:from',
         props: true,
         component: () => import('src/pages/AlternatesPage.vue'),

--- a/web/frontend/src/services/ValhallaClient.ts
+++ b/web/frontend/src/services/ValhallaClient.ts
@@ -1,6 +1,8 @@
 import { LngLat } from 'maplibre-gl';
 import { DistanceUnits } from 'src/utils/models';
+import { Err, Ok, Result } from 'src/utils/Result';
 
+// incomplete
 export interface ValhallaRouteLegManeuver {
   begin_shape_index: number;
   end_shape_index: number;
@@ -13,6 +15,19 @@ export interface ValhallaRouteLegManeuver {
   type: number;
 }
 
+// incomplete
+export enum ValhallaErrorCode {
+  UnsupportedArea = 171,
+}
+
+export type ValhallaError = {
+  error_code: ValhallaErrorCode;
+  error: string;
+  status_code: number;
+  status: string;
+};
+
+// incomplete
 export interface ValhallaRouteSummary {
   time: number;
   length: number;
@@ -22,11 +37,13 @@ export interface ValhallaRouteSummary {
   max_lon: number;
 }
 
+// incomplete
 export interface ValhallaRouteLeg {
   maneuvers: ValhallaRouteLegManeuver[];
   shape: string;
 }
 
+// incomplete
 export interface ValhallaRoute {
   legs: ValhallaRouteLeg[];
   summary: ValhallaRouteSummary;
@@ -110,7 +127,7 @@ export async function getRoutes(
   to: LngLat,
   mode: CacheableMode,
   units?: DistanceUnits
-): Promise<ValhallaRoute[]> {
+): Promise<Result<ValhallaRoute[], ValhallaError>> {
   type RouteRequest = {
     locations: Array<{ lat: number; lon: number }>;
     costing: string;
@@ -137,10 +154,12 @@ export async function getRoutes(
   const response = await fetch(
     `/valhalla/route?json=${JSON.stringify(requestObject)}`
   );
+
   if (response.status !== 200) {
-    console.error('Valhalla response gave error: ' + response.status);
-    return [];
+    const error = (await response.json()) as ValhallaError;
+    return Err(error);
   }
+
   const responseJson = await response.json();
   const routes: ValhallaRoute[] = [];
   const route = responseJson.trip as ValhallaRoute;
@@ -153,5 +172,5 @@ export async function getRoutes(
       routes.push(route);
     }
   }
-  return routes;
+  return Ok(routes);
 }

--- a/web/frontend/src/utils/Result.ts
+++ b/web/frontend/src/utils/Result.ts
@@ -1,0 +1,9 @@
+export type Result<T, E> = { ok: true; value: T } | { ok: false; error: E };
+
+export function Ok<T, E>(value: T): Result<T, E> {
+  return { ok: true, value };
+}
+
+export function Err<T, E>(error: E): Result<T, E> {
+  return { ok: false, error };
+}


### PR DESCRIPTION
Previously, when routing to unsupported locations, we just silently failed. 

Now we try to show some helpful error text

When searching for transit directions fails, we'll try to suggest the user try another mode:
![Screenshot 2022-12-16 at 2 27 36 PM](https://user-images.githubusercontent.com/217057/208183649-356303d5-d865-4822-89e6-ea01bb46552d.png)

![Screenshot 2022-12-16 at 2 27 42 PM](https://user-images.githubusercontent.com/217057/208183643-16af3025-d89a-4dc7-aef3-9b7ab79d8201.png)

