### PR TITLE
handle disabled transit

### DIFF
--- a/web/frontend/src/i18n/en-US/index.ts
+++ b/web/frontend/src/i18n/en-US/index.ts
@@ -7,6 +7,8 @@ export default {
     'Sorry, this destination is outside of our current transit coverage area.',
   transit_trip_error_unknown:
     'Sorry, unable to find transit directions for this trip.',
+  transit_routing_not_enabled:
+    'Transit directions are disabled or incorrectly configured. Please contact the server administrator',
   try_driving_directions: 'Try driving directions instead?',
   where_to_question: 'Where to?',
   my_location: 'My Location',

--- a/web/frontend/src/pages/AlternatesPage.vue
+++ b/web/frontend/src/pages/AlternatesPage.vue
@@ -115,6 +115,8 @@ export default defineComponent({
             return this.$t('transit_area_not_supported_for_source');
           case ItineraryErrorCode.DestinationOutsideBounds:
             return this.$t('transit_area_not_supported_for_destination');
+          case ItineraryErrorCode.TransitServiceDisabled:
+            return this.$t('transit_routing_not_enabled');
           case ItineraryErrorCode.Other:
             return this.$t('transit_trip_error_unknown');
         }
@@ -200,6 +202,7 @@ export default defineComponent({
           this.calculateTransitStats(trips);
           this.trips = trips;
           this.renderTrips(0);
+          this.error = undefined;
         } else {
           this.trips = [];
           this.error = result.error;


### PR DESCRIPTION
If someone is trying to use transit directions without setting up an OTP instance, we now show a  (hopefully) useful error message.