### PR TITLE
Fix: bottom UI obscured by navbar on iOS

### DIFF
--- a/web/frontend/src/components/SearchBox.vue
+++ b/web/frontend/src/components/SearchBox.vue
@@ -11,7 +11,7 @@
       :debounce="0"
       :dense="true"
       v-on:clear="selectPlace(undefined)"
-      v-on:blur="deferHide(autoCompleteMenu())"
+      v-on:blur="onBlur"
       v-on:beforeinput="
   (event: Event) =>
     updateAutocompleteEventBeforeInput(
@@ -67,7 +67,7 @@ import { defineComponent, Ref, ref } from 'vue';
 import { throttle } from 'lodash';
 import { Event, Marker } from 'maplibre-gl';
 import { map } from './BaseMap.vue';
-import { QMenu } from 'quasar';
+import { QMenu, Platform } from 'quasar';
 import Place, { PlaceId } from 'src/models/Place';
 
 const isAndroid = /(android)/i.test(navigator.userAgent);
@@ -80,6 +80,28 @@ export default defineComponent({
     readonly: Boolean,
   },
   methods: {
+    onBlur(): void {
+      if (Platform.is.ios) {
+        // iOS (on at least 16.1) "helpfully" moves the focused input towards
+        // the middle of the screen, but because out input is in a fixed header
+        // at the top of our app, this has the affect of adding a bunch of
+        // padding (~100px) at the top of our app, even after the keyboard is
+        // dismissed.
+        //
+        // I only duplicated this on a physical iPhone SE 2018 16.1. It went
+        // away after updating to 16.2, so if this work-around causes problems,
+        // we can delete it some day as the browser share declines.
+        //
+        // I don't have a physical iPhoneX style device, and couldn't induce this
+        // behavior on the simulator. I'm not sure if that's because it doesn't
+        // affect that layout, or because it doesn't affect the simulator.
+        //
+        // NOTE: scrolling to 0,0 doesn't seem to do anything. Inspecting
+        // `window.scrollY` is 0 before *and* after this scroll, so maybe the
+        // browser thinks it's a no-op.
+        window.scroll(0, -1);
+      }
+    },
     autoCompleteMenu(): QMenu {
       return this.$refs.autoCompleteMenu as QMenu;
     },

--- a/web/frontend/src/layouts/MainLayout.vue
+++ b/web/frontend/src/layouts/MainLayout.vue
@@ -21,7 +21,9 @@
   height: 100vh;
   display: flex;
   flex-direction: column;
-  flex-wrap: wrap-reverse;
+  @media screen and (min-width: 800px) {
+    flex-wrap: wrap-reverse;
+  }
 }
 
 .top-card {

--- a/web/frontend/src/layouts/MainLayout.vue
+++ b/web/frontend/src/layouts/MainLayout.vue
@@ -6,9 +6,12 @@
 </template>
 
 <style lang="scss">
-.app-container {
-  width: 100vw;
-  height: 100vh;
+.platform-ios {
+  .app-container {
+    @media screen and (max-width: 800px) {
+      height: -webkit-fill-available;
+    }
+  }
 }
 
 .app-container {

--- a/web/frontend/src/layouts/MainLayout.vue
+++ b/web/frontend/src/layouts/MainLayout.vue
@@ -41,7 +41,6 @@
   overflow-y: scroll;
   @media screen and (max-width: 800px) {
     order: 3;
-    max-height: 40%;
     width: 100%;
     box-shadow: 0px 0px 5px #00000088;
     // need z-index to cast shadow onto map
@@ -57,6 +56,10 @@
 
 #map {
   @media screen and (max-width: 800px) {
+    // This is tall enough to keep the map UI from overlapping.
+    // Ironically the "wide"/"desktop" layout is slightly less tall than the
+    // "mobile optimized" layout, which only needs about 170px
+    min-height: 190px;
     width: 100%;
     order: 2;
     flex: 1;

--- a/web/frontend/src/layouts/MainLayout.vue
+++ b/web/frontend/src/layouts/MainLayout.vue
@@ -1,9 +1,7 @@
 <template>
   <div class="app-container" :class="appClass">
-    <div class="flex-container">
-      <router-view />
-      <base-map />
-    </div>
+    <router-view />
+    <base-map />
   </div>
 </template>
 
@@ -13,9 +11,11 @@
   height: 100vh;
 }
 
-.flex-container {
+.app-container {
   width: 100%;
-  height: 100%;
+  // iPhoneX content is beyond screen boundary
+  //height: calc(100vh - 50px);
+  height: 100vh;
   display: flex;
   flex-direction: column;
   flex-wrap: wrap-reverse;

--- a/web/frontend/src/pages/AlternatesPage.vue
+++ b/web/frontend/src/pages/AlternatesPage.vue
@@ -204,6 +204,9 @@ export default defineComponent({
           this.trips = [];
           this.error = result.error;
         }
+      } else {
+        this.trips = [];
+        this.error = undefined;
       }
 
       if (fromPlace.value) {


### PR DESCRIPTION
This broke in #211. That's what I get for only testing on Safari's "responsive design mode" vs. an actual iOS device.

This isn't a complete fix, for instance, there's some unutilized screen real estate on iPhoneX style devices, but this should make things usable.