### PR TITLE
Don't unnecessarily redraw the route when viewing steps

### DIFF
--- a/web/frontend/src/models/TripLayerId.ts
+++ b/web/frontend/src/models/TripLayerId.ts
@@ -1,0 +1,24 @@
+export default class TripLayerId {
+  tripIdx: number;
+  legIdx: number;
+  selected: boolean;
+
+  constructor(tripIdx: number, legIdx: number, selected: boolean) {
+    this.tripIdx = tripIdx;
+    this.legIdx = legIdx;
+    this.selected = selected;
+  }
+
+  static selected(tripIdx: number, legIdx: number): TripLayerId {
+    return new TripLayerId(tripIdx, legIdx, true);
+  }
+
+  static unselected(tripIdx: number, legIdx: number): TripLayerId {
+    return new TripLayerId(tripIdx, legIdx, false);
+  }
+
+  public toString(): string {
+    const selectionState = this.selected ? 'selected' : 'unselected';
+    return `trip_${this.tripIdx}_leg_${this.legIdx}_${selectionState}`;
+  }
+}

--- a/web/frontend/src/pages/PlacePage.vue
+++ b/web/frontend/src/pages/PlacePage.vue
@@ -39,6 +39,7 @@ function renderOnMap(place: Place) {
     'active_marker',
     new Marker({ color: '#111111' }).setLngLat(place.point)
   );
+  map.removeAllLayers();
   map.removeMarkersExcept(['active_marker']);
 }
 

--- a/web/frontend/src/router/routes.ts
+++ b/web/frontend/src/router/routes.ts
@@ -50,11 +50,11 @@ const routes: RouteRecordRaw[] = [
     ],
   },
   {
-    path: '/directions/:mode/:to/:from/:alternateIndex',
+    path: '/directions/:mode/:to/:from/:tripIdx',
     component: () => import('layouts/MainLayout.vue'),
     children: [
       {
-        path: '/directions/:mode/:to/:from/:alternateIndex',
+        path: '/directions/:mode/:to/:from/:tripIdx',
         props: true,
         component: () => import('src/pages/StepsPage.vue'),
       },


### PR DESCRIPTION
If the routes already drawn, just leave it, don't remove it only to redraw it. This can avoid a little flicker.

As part of this I centralized the code that generates layer ids.