### PR TITLE
Fix GitHub Actions status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # <p align=center>Headway</p>
 
 <p align=center>
-<img alt="GitHub Actions status badge" src="https://github.com/headwaymaps/headway/actions/workflows/main.yml/badge.svg?branch=main"/>
+<img alt="GitHub Actions status badge" src="https://github.com/headwaymaps/headway/actions/workflows/checks.yml/badge.svg?branch=main"/>
 <img alt="License badge" src="https://img.shields.io/github/license/headwaymaps/headway"/>
 <img alt="GitHub last commit badge" src="https://img.shields.io/github/last-commit/headwaymaps/headway"/>
 <img alt="GitHub commit activity badge" src="https://img.shields.io/github/commit-activity/m/headwaymaps/headway"/>


### PR DESCRIPTION
Link for the status badge was broken: File `main.yml` did not exist in `headwaymaps/headway/.github/workflows/`.   
Screenshot before: 
![image](https://user-images.githubusercontent.com/24467345/213402030-65506e35-02e8-4fba-9be8-e23ae78ebac6.png)
Screenshot after: 
![image](https://user-images.githubusercontent.com/24467345/213402176-6d463aeb-e961-4f71-9928-8799c6d4f36e.png)
