### PR TITLE
[www] Fix some distances shown in non-preferred units.

### DIFF
--- a/web/frontend/src/components/BaseMap.vue
+++ b/web/frontend/src/components/BaseMap.vue
@@ -31,10 +31,10 @@ async function loadMap(): Promise<maplibregl.Map> {
   let initialCenter: LngLatLike = [0, 0];
   let initialZoom = 1;
 
-  const mostRecentMapCenter = Prefs.stored().mostRecentMapCenter();
+  const mostRecentMapCenter = Prefs.stored.mostRecentMapCenter;
   if (mostRecentMapCenter) {
     initialCenter = mostRecentMapCenter;
-    const mostRecentMapZoom = Prefs.stored().mostRecentMapZoom();
+    const mostRecentMapZoom = Prefs.stored.mostRecentMapZoom;
     if (mostRecentMapZoom) {
       initialZoom = Math.min(10, mostRecentMapZoom);
     }
@@ -419,8 +419,8 @@ export default defineComponent({
     map.on(
       'moveend',
       debounce(() => {
-        Prefs.stored().setMostRecentMapCenter(map.getCenter());
-        Prefs.stored().setMostRecentMapZoom(map.getZoom());
+        Prefs.stored.setMostRecentMapCenter(map.getCenter());
+        Prefs.stored.setMostRecentMapZoom(map.getZoom());
       }, 2000)
     );
 

--- a/web/frontend/src/models/Itinerary.ts
+++ b/web/frontend/src/models/Itinerary.ts
@@ -140,12 +140,13 @@ export default class Itinerary implements Trip {
   }
 
   public walkingDistanceFormatted(): string {
-    let distance = this.walkingDistanceMeters;
-    if (this.distanceUnits != DistanceUnits.Kilometers) {
-      distance = kilometersToMiles(distance / 1000);
+    const km = this.walkingDistanceMeters / 1000;
+    if (this.distanceUnits == DistanceUnits.Kilometers) {
+      return formatDistance(km, DistanceUnits.Kilometers);
+    } else {
+      const miles = kilometersToMiles(km);
+      return formatDistance(miles, DistanceUnits.Miles);
     }
-
-    return formatDistance(distance, this.distanceUnits);
   }
 
   public get viaRouteFormatted(): string | undefined {

--- a/web/frontend/src/models/Place.ts
+++ b/web/frontend/src/models/Place.ts
@@ -214,7 +214,7 @@ export default class Place {
     if (imperialDogs.includes(this.countryCode)) {
       return DistanceUnits.Miles;
     } else {
-      return undefined;
+      return DistanceUnits.Kilometers;
     }
   }
 }

--- a/web/frontend/src/pages/AlternatesPage.vue
+++ b/web/frontend/src/pages/AlternatesPage.vue
@@ -62,7 +62,6 @@ import {
   sourceMarker,
   getBaseMap,
 } from 'src/components/BaseMap.vue';
-import { DistanceUnits } from 'src/utils/models';
 import { Component, defineComponent, Ref, ref } from 'vue';
 import Place, { PlaceStorage } from 'src/models/Place';
 import { TravelMode } from 'src/utils/models';
@@ -74,6 +73,7 @@ import Trip, { fetchBestTrips, TripFetchError } from 'src/models/Trip';
 import TripLayerId from 'src/models/TripLayerId';
 import Itinerary, { ItineraryErrorCode } from 'src/models/Itinerary';
 import { RouteErrorCode } from 'src/models/Route';
+import Prefs from 'src/utils/Prefs';
 
 export default defineComponent({
   name: 'AlternatesPage',
@@ -191,7 +191,7 @@ export default defineComponent({
           this.fromPlace.point,
           this.toPlace.point,
           this.mode,
-          this.fromPlace.preferredDistanceUnits() ?? DistanceUnits.Kilometers
+          Prefs.stored.distanceUnits(this.fromPlace, this.toPlace)
         );
         if (result.ok) {
           const trips = result.value;

--- a/web/frontend/src/pages/AlternatesPage.vue
+++ b/web/frontend/src/pages/AlternatesPage.vue
@@ -75,9 +75,6 @@ import TripLayerId from 'src/models/TripLayerId';
 import Itinerary, { ItineraryErrorCode } from 'src/models/Itinerary';
 import { RouteErrorCode } from 'src/models/Route';
 
-let toPlace: Ref<Place | undefined> = ref(undefined);
-let fromPlace: Ref<Place | undefined> = ref(undefined);
-
 export default defineComponent({
   name: 'AlternatesPage',
   props: {
@@ -163,18 +160,18 @@ export default defineComponent({
       }
     },
     clickedSwap(newFromValue?: Place, newToValue?: Place) {
-      fromPlace.value = newFromValue;
-      toPlace.value = newToValue;
+      this.fromPlace = newFromValue;
+      this.toPlace = newToValue;
       this.rewriteUrl();
     },
     rewriteUrl: async function () {
-      if (!fromPlace.value && !toPlace.value) {
+      if (!this.fromPlace && !this.toPlace) {
         this.$router.push('/');
         return;
       }
 
-      const fromEncoded = fromPlace.value?.urlEncodedId() ?? '_';
-      const toEncoded = toPlace.value?.urlEncodedId() ?? '_';
+      const fromEncoded = this.fromPlace?.urlEncodedId() ?? '_';
+      const toEncoded = this.toPlace?.urlEncodedId() ?? '_';
       this.$router.push(`/directions/${this.mode}/${toEncoded}/${fromEncoded}`);
       await this.updateTrips();
     },
@@ -189,12 +186,12 @@ export default defineComponent({
       map.removeAllLayers();
       map.removeAllMarkers();
 
-      if (fromPlace.value && toPlace.value) {
+      if (this.fromPlace && this.toPlace) {
         const result = await fetchBestTrips(
-          fromPlace.value.point,
-          toPlace.value.point,
+          this.fromPlace.point,
+          this.toPlace.point,
           this.mode,
-          fromPlace.value.preferredDistanceUnits() ?? DistanceUnits.Kilometers
+          this.fromPlace.preferredDistanceUnits() ?? DistanceUnits.Kilometers
         );
         if (result.ok) {
           const trips = result.value;
@@ -211,17 +208,17 @@ export default defineComponent({
         this.error = undefined;
       }
 
-      if (fromPlace.value) {
+      if (this.fromPlace) {
         map.pushMarker(
           'source_marker',
-          sourceMarker().setLngLat(fromPlace.value.point)
+          sourceMarker().setLngLat(this.fromPlace.point)
         );
       }
 
-      if (toPlace.value) {
+      if (this.toPlace) {
         map.pushMarker(
           'destination_marker',
-          destinationMarker().setLngLat(toPlace.value.point)
+          destinationMarker().setLngLat(this.toPlace.point)
         );
       }
     },
@@ -313,12 +310,12 @@ export default defineComponent({
   },
   mounted: async function () {
     if (this.to != '_') {
-      toPlace.value = await PlaceStorage.fetchFromSerializedId(
+      this.toPlace = await PlaceStorage.fetchFromSerializedId(
         this.to as string
       );
     }
     if (this.from != '_') {
-      fromPlace.value = await PlaceStorage.fetchFromSerializedId(
+      this.fromPlace = await PlaceStorage.fetchFromSerializedId(
         this.from as string
       );
     }
@@ -326,6 +323,9 @@ export default defineComponent({
     await this.rewriteUrl();
   },
   setup: function () {
+    let toPlace: Ref<Place | undefined> = ref(undefined);
+    let fromPlace: Ref<Place | undefined> = ref(undefined);
+
     return {
       toPlace,
       fromPlace,

--- a/web/frontend/src/pages/AlternatesPage.vue
+++ b/web/frontend/src/pages/AlternatesPage.vue
@@ -260,8 +260,7 @@ export default defineComponent({
           map.on('mouseout', layerId.toString(), () => {
             map.setCursor('');
           });
-          map.on('click', layerId.toString(), (e) => {
-            console.log('clicked', e);
+          map.on('click', layerId.toString(), () => {
             this.clickTrip(trip);
           });
         }

--- a/web/frontend/src/pages/StepsPage.vue
+++ b/web/frontend/src/pages/StepsPage.vue
@@ -48,9 +48,6 @@ import MultiModalSteps from 'src/components/MultiModalSteps.vue';
 import SearchBox from 'src/components/SearchBox.vue';
 import TripLayerId from 'src/models/TripLayerId';
 
-let toPlace: Ref<Place | undefined> = ref(undefined);
-let fromPlace: Ref<Place | undefined> = ref(undefined);
-
 export default defineComponent({
   name: 'StepsPage',
   props: {
@@ -92,8 +89,8 @@ export default defineComponent({
     },
 
     goToAlternates() {
-      const fromEncoded = fromPlace.value?.urlEncodedId() ?? '_';
-      const toEncoded = toPlace.value?.urlEncodedId() ?? '_';
+      const fromEncoded = this.fromPlace?.urlEncodedId() ?? '_';
+      const toEncoded = this.toPlace?.urlEncodedId() ?? '_';
       this.$router.push(`/directions/${this.mode}/${toEncoded}/${fromEncoded}`);
     },
 
@@ -104,18 +101,18 @@ export default defineComponent({
         return;
       }
 
-      const fromEncoded = fromPlace.value?.urlEncodedId() ?? '_';
-      const toEncoded = toPlace.value?.urlEncodedId() ?? '_';
+      const fromEncoded = this.fromPlace?.urlEncodedId() ?? '_';
+      const toEncoded = this.toPlace?.urlEncodedId() ?? '_';
       this.$router.push(
         `/directions/${this.mode}/${toEncoded}/${fromEncoded}/${this.tripIdx}`
       );
 
-      if (fromPlace.value && toPlace.value) {
+      if (this.fromPlace && this.toPlace) {
         const result = await fetchBestTrips(
-          fromPlace.value.point,
-          toPlace.value.point,
+          this.fromPlace.point,
+          this.toPlace.point,
           this.mode,
-          fromPlace.value.preferredDistanceUnits() ?? DistanceUnits.Kilometers
+          this.fromPlace.preferredDistanceUnits() ?? DistanceUnits.Kilometers
         );
         if (!result.ok) {
           console.error('fetchBestTrips.error', result.error);
@@ -161,10 +158,10 @@ export default defineComponent({
     },
   },
   mounted: async function () {
-    toPlace.value = await PlaceStorage.fetchFromSerializedId(
+    this.toPlace = await PlaceStorage.fetchFromSerializedId(
       this.$props.to as string
     );
-    fromPlace.value = await PlaceStorage.fetchFromSerializedId(
+    this.fromPlace = await PlaceStorage.fetchFromSerializedId(
       this.$props.from as string
     );
 
@@ -190,21 +187,24 @@ export default defineComponent({
     });
 
     map.removeAllMarkers();
-    if (fromPlace.value) {
+    if (this.fromPlace) {
       map.pushMarker(
         'source_marker',
-        sourceMarker().setLngLat(fromPlace.value.point)
+        sourceMarker().setLngLat(this.fromPlace.point)
       );
     }
 
-    if (toPlace.value) {
+    if (this.toPlace) {
       map.pushMarker(
         'destination_marker',
-        destinationMarker().setLngLat(toPlace.value.point)
+        destinationMarker().setLngLat(this.toPlace.point)
       );
     }
   },
   setup: function () {
+    let toPlace: Ref<Place | undefined> = ref(undefined);
+    let fromPlace: Ref<Place | undefined> = ref(undefined);
+
     return {
       toPlace,
       fromPlace,

--- a/web/frontend/src/utils/Prefs.ts
+++ b/web/frontend/src/utils/Prefs.ts
@@ -3,7 +3,7 @@ import { isEqual } from 'lodash';
 
 export default class Prefs {
   private static _stored: Prefs | undefined;
-  static stored(): Prefs {
+  static get stored(): Prefs {
     if (Prefs._stored === undefined) {
       Prefs._stored = new Prefs(window.localStorage);
     }
@@ -17,7 +17,7 @@ export default class Prefs {
   }
 
   private _mostRecentMapZoom: number | undefined | null;
-  mostRecentMapZoom(): number | null {
+  get mostRecentMapZoom(): number | null {
     if (this._mostRecentMapZoom !== undefined) {
       return this._mostRecentMapZoom;
     }
@@ -54,7 +54,7 @@ export default class Prefs {
   }
 
   private _mostRecentMapCenter: LngLatLike | undefined | null;
-  mostRecentMapCenter(): LngLatLike | null {
+  get mostRecentMapCenter(): LngLatLike | null {
     if (this._mostRecentMapCenter !== undefined) {
       return this._mostRecentMapCenter;
     }
@@ -82,7 +82,7 @@ export default class Prefs {
     }
   }
 
-  setMostRecentMapCenter(lnglat: LngLatLike) {
+  setMostRecentMapCenter(lnglat: LngLatLike): void {
     const coords = LngLat.convert(lnglat).toArray();
 
     if (isEqual(coords, [0, 0])) {


### PR DESCRIPTION
Primarily: Fix some distances in non-preferred units.

(But in the process of debugging, I fixed up some other things, each in mostly tidy commits.)

In particular "use current location" doesn't do a geocoding request, which is when we'd get the country-code used to guess the preferred units.

Now we try two more things before falling back to the default unit (km):

1. fall back to the "to" location if the "from" location lacks a country code.
2. if both to/from lack units, fall back to whatever the previously used units were.

To reproduce the previous bug:

1. Search for "Fremont Troll"
2. Click "Transit" directions
3. Be somewhere in Seattle and click from "my location"
4. See "0.5 km of walking" but expect to see "0.3 _mi_ of walking" 

