### PR TITLE
[www] color transit routes, unify line styles

### DIFF
--- a/web/frontend/src/models/Itinerary.ts
+++ b/web/frontend/src/models/Itinerary.ts
@@ -16,7 +16,7 @@ import {
   kilometersToMiles,
 } from 'src/utils/format';
 import { decodeOtpPath } from 'src/third_party/decodePath';
-import Trip from './Trip';
+import Trip, { LineStyles } from './Trip';
 import { Err, Ok, Result } from 'src/utils/Result';
 
 export enum ItineraryErrorCode {
@@ -218,11 +218,23 @@ export class ItineraryLeg {
   }
 
   paintStyle(active: boolean): LineLayerSpecification['paint'] {
-    return {
-      'line-color': active ? (this.transitLeg ? '#E21919' : '#1976D2') : '#777',
-      'line-width': this.transitLeg ? 6 : 4,
-      'line-dasharray': this.transitLeg ? [1] : [1, 2],
-    };
+    if (active) {
+      if (this.mode == OTPMode.Walk) {
+        return LineStyles.walkingActive;
+      } else {
+        if (this.raw.routeColor) {
+          return LineStyles.activeColored(`#${this.raw.routeColor}`);
+        } else {
+          return LineStyles.active;
+        }
+      }
+    } else {
+      if (this.mode == OTPMode.Walk) {
+        return LineStyles.walkingInactive;
+      } else {
+        return LineStyles.inactive;
+      }
+    }
   }
 
   get sourceName(): string {

--- a/web/frontend/src/models/Trip.ts
+++ b/web/frontend/src/models/Trip.ts
@@ -50,3 +50,30 @@ export async function fetchBestTrips(
     }
   }
 }
+
+export const LineStyles = {
+  activeColored(color: string): LineLayerSpecification['paint'] {
+    return {
+      'line-color': color,
+      'line-width': 6,
+    };
+  },
+  active: {
+    'line-color': '#1976D2',
+    'line-width': 6,
+  },
+  inactive: {
+    'line-color': '#777',
+    'line-width': 4,
+  },
+  walkingActive: {
+    'line-color': '#1976D2',
+    'line-dasharray': [0, 1.5],
+    'line-width': 8,
+  },
+  walkingInactive: {
+    'line-color': '#777',
+    'line-dasharray': [0, 1.5],
+    'line-width': 8,
+  },
+};

--- a/web/frontend/src/services/OTPClient.ts
+++ b/web/frontend/src/services/OTPClient.ts
@@ -9,16 +9,16 @@ export type OTPLegGeometry = {
 export enum OTPMode {
   Bicycle = 'BICYCLE',
   Bus = 'BUS',
-  Car = 'CAR',
   CableCar = 'CABLE_CAR',
+  Car = 'CAR',
   Ferry = 'FERRY',
   Funicular = 'FUNICULAR',
   Gondola = 'GONDOLA',
   Rail = 'RAIL',
   Subway = 'SUBWAY',
   Train = 'TRAIN',
-  Transit = 'TRANSIT',
   Tram = 'TRAM',
+  Transit = 'TRANSIT',
   Walk = 'WALK',
 }
 
@@ -47,6 +47,7 @@ export type OTPItineraryLeg = {
   route: string;
   routeShortName?: string;
   routeLongName?: string;
+  routeColor?: string;
   from: { name: string; lat: number; lon: number };
   to: { name: string; lat: number; lon: number };
 };

--- a/web/frontend/src/services/ValhallaClient.ts
+++ b/web/frontend/src/services/ValhallaClient.ts
@@ -7,6 +7,7 @@ export interface ValhallaRouteLegManeuver {
   begin_shape_index: number;
   end_shape_index: number;
   street_names?: string[];
+  travel_mode: ValhallaTravelMode;
   time: number;
   cost: number;
   length: number;
@@ -35,6 +36,15 @@ export interface ValhallaRouteSummary {
   min_lon: number;
   max_lat: number;
   max_lon: number;
+}
+
+// From https://github.com/valhalla/valhalla-docs/blob/master/turn-by-turn/api-reference.md
+// See also: travel_type for transit sub types like tram, ferry, etc.
+export enum ValhallaTravelMode {
+  Bicycle = 'bicycle',
+  Drive = 'drive',
+  Transit = 'transit',
+  Walk = 'pedestrian',
 }
 
 // incomplete


### PR DESCRIPTION
Some transit routes are associated with a color. We now color the active transit route according to this color when OTP makes this available.

<img width="868" alt="Screenshot 2023-01-31 at 12 10 43 PM" src="https://user-images.githubusercontent.com/217057/215872416-f072378a-cead-4ddf-ab06-310580e128e6.png">


(Thanks to @spammads for making me aware of this api!)