### PR TITLE
Only build the `latest` containers when a new tag is pushed. 

### DIFF
--- a/.github/workflows/push-latest-containers.yml
+++ b/.github/workflows/push-latest-containers.yml
@@ -1,8 +1,9 @@
-name: Push
+name: Push `latest` containers
 
 on:
   push:
-    branches: [main]
+    tags:
+      - 'v*'
 
 jobs:
   build:
@@ -18,4 +19,5 @@ jobs:
       - name: Earthly version check
         run: earthly --version
       - name: Push images
-        run: earthly --push +images
+        run: earthly --push +images --tag "latest ${{ github.ref_name }}"
+

--- a/Earthfile
+++ b/Earthfile
@@ -17,14 +17,14 @@ build:
     ARG countries
 
     # tag for created docker containers
-    ARG tag="latest"
+    ARG tags="dev"
 
     # Run +gtfs-enumerate to build an appropriate input for transit_feeds.
     # If omitted, you cannot enable transit routing.
     ARG transit_feeds
 
     BUILD +save --area=${area} --countries=${countries} --transit_feeds=${transit_feeds}
-    BUILD +images --tag=${tag}
+    BUILD +images --tags=${tags}
 
 save:
     FROM +save-base
@@ -119,18 +119,18 @@ save-tileserver-natural-earth:
 
 images:
     FROM debian:bullseye-slim
-    ARG tag="latest"
+    ARG tags="dev"
     ARG branding
-    BUILD +transitmux-serve-image --tag=${tag}
-    BUILD +otp-serve-image --tag=${tag}
-    BUILD +valhalla-serve-image --tag=${tag}
-    BUILD +web-serve-image --tag=${tag} --branding=${branding}
-    BUILD +tileserver-serve-image --tag=${tag}
-    BUILD +otp-init-image --tag=${tag}
-    BUILD +valhalla-init-image --tag=${tag}
-    BUILD +web-init-image --tag=${tag}
-    BUILD +tileserver-init-image --tag=${tag}
-    BUILD +pelias-init-image --tag=${tag}
+    BUILD +transitmux-serve-image --tags=${tags}
+    BUILD +otp-serve-image --tags=${tags}
+    BUILD +valhalla-serve-image --tags=${tags}
+    BUILD +web-serve-image --tags=${tags} --branding=${branding}
+    BUILD +tileserver-serve-image --tags=${tags}
+    BUILD +otp-init-image --tags=${tags}
+    BUILD +valhalla-init-image --tags=${tags}
+    BUILD +web-init-image --tags=${tags}
+    BUILD +tileserver-init-image --tags=${tags}
+    BUILD +pelias-init-image --tags=${tags}
 
 extract:
     FROM +downloader-base
@@ -150,8 +150,10 @@ pelias-init-image:
     RUN mkdir -p /app
     COPY ./services/pelias/init* /app/
     CMD ["echo", "run a specific command"]
-    ARG tag
-    SAVE IMAGE --push ghcr.io/headwaymaps/pelias-init:${tag}
+    ARG --required tags
+    FOR tag IN ${tags}
+        SAVE IMAGE --push ghcr.io/headwaymaps/pelias-init:${tag}
+    END
 
 pelias-guess-country:
     FROM debian:bullseye-slim
@@ -425,8 +427,10 @@ otp-init-image:
     FROM +downloader-base
     COPY ./services/otp/init.sh /app/init.sh
     CMD ["/app/init.sh"]
-    ARG tag
-    SAVE IMAGE --push ghcr.io/headwaymaps/opentripplanner-init:${tag}
+    ARG --required tags
+    FOR tag IN ${tags}
+        SAVE IMAGE --push ghcr.io/headwaymaps/opentripplanner-init:${tag}
+    END
 
 otp-serve-image:
     FROM +otp-base
@@ -447,8 +451,10 @@ otp-serve-image:
     HEALTHCHECK --interval=5s --start-period=120s \
         CMD nc -z localhost ${PORT}
 
-    ARG tag
-    SAVE IMAGE --push ghcr.io/headwaymaps/opentripplanner:${tag}
+    ARG --required tags
+    FOR tag IN ${tags}
+        SAVE IMAGE --push ghcr.io/headwaymaps/opentripplanner:${tag}
+    END
 
 build-transitmux:
     FROM rust
@@ -484,8 +490,10 @@ transitmux-serve-image:
     ENTRYPOINT ["/home/transitmux/transitmux-server"]
     CMD ["http://opentripplanner:8000/otp/routers"]
 
-    ARG tag
-    SAVE IMAGE --push ghcr.io/headwaymaps/transitmux:${tag}
+    ARG --required tags
+    FOR tag IN ${tags}
+        SAVE IMAGE --push ghcr.io/headwaymaps/transitmux:${tag}
+    END
 
 ##############################
 # Valhalla
@@ -537,16 +545,20 @@ valhalla-init-image:
     ENTRYPOINT ["/bin/bash"]
     USER root
     CMD ["/app/init.sh"]
-    ARG tag
-    SAVE IMAGE --push ghcr.io/headwaymaps/valhalla-init:${tag}
+    ARG --required tags
+    FOR tag IN ${tags}
+        SAVE IMAGE --push ghcr.io/headwaymaps/valhalla-init:${tag}
+    END
 
 valhalla-serve-image:
     FROM +valhalla-base-image
     ENTRYPOINT ["valhalla_service"]
     USER valhalla
     CMD ["/data/valhalla.json"]
-    ARG tag
-    SAVE IMAGE --push ghcr.io/headwaymaps/valhalla:${tag}
+    ARG --required tags
+    FOR tag IN ${tags}
+        SAVE IMAGE --push ghcr.io/headwaymaps/valhalla:${tag}
+    END
 
 ##############################
 # tileserver-gl-light
@@ -606,8 +618,10 @@ tileserver-init-image:
 
     COPY ./services/tileserver/init.sh /app/init.sh
     CMD ["/app/init.sh"]
-    ARG tag
-    SAVE IMAGE --push ghcr.io/headwaymaps/tileserver-init:${tag}
+    ARG --required tags
+    FOR tag IN ${tags}
+        SAVE IMAGE --push ghcr.io/headwaymaps/tileserver-init:${tag}
+    END
 
 tileserver-serve-image:
     FROM node:16
@@ -634,8 +648,10 @@ tileserver-serve-image:
 
     ENV HEADWAY_PUBLIC_URL=http://127.0.0.1:8080
     CMD ["/app/configure_run.sh"]
-    ARG tag
-    SAVE IMAGE --push ghcr.io/headwaymaps/tileserver:${tag}
+    ARG --required tags
+    FOR tag IN ${tags}
+        SAVE IMAGE --push ghcr.io/headwaymaps/tileserver:${tag}
+    END
 
 ##############################
 # Web
@@ -660,8 +676,10 @@ web-init-image:
     ENV HEADWAY_SHARED_VOL=/data
     CMD ["/app/init.sh"]
 
-    ARG tag
-    SAVE IMAGE --push ghcr.io/headwaymaps/headway-init:${tag}
+    ARG --required tags
+    FOR tag IN ${tags}
+        SAVE IMAGE --push ghcr.io/headwaymaps/headway-init:${tag}
+    END
 
 web-serve-image:
     FROM nginx
@@ -683,8 +701,10 @@ web-serve-image:
     ENV ESC=$
     ENV NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx
 
-    ARG tag
-    SAVE IMAGE --push ghcr.io/headwaymaps/headway:${tag}
+    ARG --required tags
+    FOR tag IN ${tags}
+        SAVE IMAGE --push ghcr.io/headwaymaps/headway:${tag}
+    END
 
 ##############################
 # Generic base images

--- a/bin/_headway_version.sh
+++ b/bin/_headway_version.sh
@@ -19,17 +19,6 @@
 # be built and deployed before the corresponding containers can be deployed.
 export HEADWAY_DATA_TAG=0.3.0
 
-# Tracks backwards incompatibility between container deployments.
-#
-# Major bumps to HEADWAY_CONTAINER_TAG might require a fresh deploy
-# of the entire system. Minor or patch bumps should be deployable by replacing
-# individual containers in place.
-#
-# Of course, you can always do a fresh deploy of the entire system if you are
-# OK with downtime or have a blue/green deployment setup.
-export HEADWAY_CONTAINER_TAG=0.4.0
-
-
 # # Schema change Log
 #
 # This documents the changes to the schema tag's over time, not *every* change

--- a/k8s/bin/generate
+++ b/k8s/bin/generate
@@ -30,12 +30,11 @@ OUTPUT_DIR="$2"
 source "${REPO_ROOT}/.env"
 
 # stash env vars in local before they get clobbered by _headway_version.sh
-local_container_tag=$HEADWAY_CONTAINER_TAG
 local_data_tag=$HEADWAY_DATA_TAG
 source "${REPO_ROOT}/bin/_headway_version.sh"
-
-export HEADWAY_CONTAINER_TAG="${local_container_tag:-$HEADWAY_CONTAINER_TAG}"
 export HEADWAY_DATA_TAG="${local_data_tag:-$HEADWAY_DATA_TAG}"
+
+export HEADWAY_CONTAINER_TAG="${HEADWAY_CONTAINER_TAG:-latest}"
 
 source "$DEPLOYMENT_ENV_FILE"
 

--- a/k8s/configs/planet/frontend-deployment.yaml
+++ b/k8s/configs/planet/frontend-deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     storage: 50Mi
       initContainers:
         - name: init
-          image: ghcr.io/headwaymaps/headway-init:0.4.0
+          image: ghcr.io/headwaymaps/headway-init:latest
           imagePullPolicy: Always
           volumeMounts:
             - name: headway-volume
@@ -46,7 +46,7 @@ spec:
               memory: 100Mi
       containers:
         - name: main
-          image: ghcr.io/headwaymaps/headway:0.4.0
+          image: ghcr.io/headwaymaps/headway:latest
           imagePullPolicy: Always
           volumeMounts:
             - name: headway-volume

--- a/k8s/configs/planet/opentripplanner-losangeles-deployment.yaml
+++ b/k8s/configs/planet/opentripplanner-losangeles-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       initContainers:
         - name: init
-          image: ghcr.io/headwaymaps/opentripplanner-init:0.4.0
+          image: ghcr.io/headwaymaps/opentripplanner-init:latest
           imagePullPolicy: Always
           volumeMounts:
             - name: opentripplanner-volume
@@ -32,7 +32,7 @@ spec:
               memory: 128Mi
       containers:
         - name: main
-          image: ghcr.io/headwaymaps/opentripplanner:0.4.0
+          image: ghcr.io/headwaymaps/opentripplanner:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 8000

--- a/k8s/configs/planet/opentripplanner-seattle-deployment.yaml
+++ b/k8s/configs/planet/opentripplanner-seattle-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       initContainers:
         - name: init
-          image: ghcr.io/headwaymaps/opentripplanner-init:0.4.0
+          image: ghcr.io/headwaymaps/opentripplanner-init:latest
           imagePullPolicy: Always
           volumeMounts:
             - name: opentripplanner-volume
@@ -32,7 +32,7 @@ spec:
               memory: 128Mi
       containers:
         - name: main
-          image: ghcr.io/headwaymaps/opentripplanner:0.4.0
+          image: ghcr.io/headwaymaps/opentripplanner:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 8000

--- a/k8s/configs/planet/pelias-api-deployment.yaml
+++ b/k8s/configs/planet/pelias-api-deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       initContainers:
         - name: init
-          image: ghcr.io/headwaymaps/pelias-init:0.4.0
+          image: ghcr.io/headwaymaps/pelias-init:latest
           imagePullPolicy: Always
           volumeMounts:
             - name: config-volume

--- a/k8s/configs/planet/pelias-elasticsearch-deployment.yaml
+++ b/k8s/configs/planet/pelias-elasticsearch-deployment.yaml
@@ -32,7 +32,7 @@ spec:
                     storage: 1Mi
       initContainers:
         - name: init
-          image: ghcr.io/headwaymaps/pelias-init:0.4.0
+          image: ghcr.io/headwaymaps/pelias-init:latest
           imagePullPolicy: Always
           volumeMounts:
             - name: elasticsearch-volume

--- a/k8s/configs/planet/pelias-placeholder-deployment.yaml
+++ b/k8s/configs/planet/pelias-placeholder-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       initContainers:
         - name: init
-          image: ghcr.io/headwaymaps/pelias-init:0.4.0
+          image: ghcr.io/headwaymaps/pelias-init:latest
           imagePullPolicy: Always
           volumeMounts:
             - name: placeholder-volume

--- a/k8s/configs/planet/tileserver-deployment.yaml
+++ b/k8s/configs/planet/tileserver-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       initContainers:
         - name: init
-          image: ghcr.io/headwaymaps/tileserver-init:0.4.0
+          image: ghcr.io/headwaymaps/tileserver-init:latest
           imagePullPolicy: Always
           volumeMounts:
             - name: tileserver-volume
@@ -43,7 +43,7 @@ spec:
               memory: 100Mi
       containers:
         - name: tileserver
-          image: ghcr.io/headwaymaps/tileserver:0.4.0
+          image: ghcr.io/headwaymaps/tileserver:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 8000

--- a/k8s/configs/planet/transitmux-deployment.yaml
+++ b/k8s/configs/planet/transitmux-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: main
-          image: ghcr.io/headwaymaps/transitmux:0.4.0
+          image: ghcr.io/headwaymaps/transitmux:latest
           imagePullPolicy: Always
           args: ["http://opentripplanner-seattle:8000/otp/routers", "http://opentripplanner-losangeles:8000/otp/routers"]
           ports:

--- a/k8s/configs/planet/valhalla-deployment.yaml
+++ b/k8s/configs/planet/valhalla-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       initContainers:
         - name: init
-          image: ghcr.io/headwaymaps/valhalla-init:0.4.0
+          image: ghcr.io/headwaymaps/valhalla-init:latest
           imagePullPolicy: Always
           volumeMounts:
             - name: valhalla-volume
@@ -32,7 +32,7 @@ spec:
               memory: 100Mi
       containers:
         - name: main
-          image: ghcr.io/headwaymaps/valhalla:0.4.0
+          image: ghcr.io/headwaymaps/valhalla:latest
           imagePullPolicy: Always
           ports:
           - containerPort: 8002


### PR DESCRIPTION
This should hopefully make it a little easier to manage updates and the occasional rollback.