### PR TITLE
introduce search page

### DIFF
--- a/web/frontend/.vscode/settings.json
+++ b/web/frontend/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.bracketPairColorization.enabled": true,
   "editor.guides.bracketPairs": true,
-  "editor.formatOnSave": true,
+  "editor.formatOnSave": false,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": ["source.fixAll.eslint"],
   "eslint.validate": ["javascript", "javascriptreact", "typescript", "vue"],

--- a/web/frontend/src/components/BaseMap.vue
+++ b/web/frontend/src/components/BaseMap.vue
@@ -6,8 +6,11 @@
 import { defineComponent } from 'vue';
 import maplibregl, {
   FitBoundsOptions,
+  FlyToOptions,
   LayerSpecification,
   LineLayerSpecification,
+  LngLat,
+  LngLatBounds,
   LngLatBoundsLike,
   LngLatLike,
   MapLayerEventType,
@@ -21,7 +24,7 @@ import Prefs from 'src/utils/Prefs';
 import Config from 'src/utils/Config';
 import { mapFeatureToPlace } from 'src/utils/models';
 import { debounce } from 'lodash';
-import { PlaceId } from 'src/models/Place';
+import Place, { PlaceId } from 'src/models/Place';
 import TripLayerId from 'src/models/TripLayerId';
 import env from 'src/utils/env';
 
@@ -82,7 +85,11 @@ function clearAllTimeouts() {
 }
 
 export interface BaseMapInterface {
-  flyTo: (location: LngLatLike, zoom: number) => Promise<void>;
+  getZoom: () => number;
+  getCenter: () => LngLat;
+  getBounds: () => LngLatBounds;
+  flyTo: (location: LngLatLike, zoom?: number) => void;
+  flyToPlace: (place: Place) => void;
   fitBounds: (bounds: LngLatBoundsLike, options?: FitBoundsOptions) => void;
   setCursor: (key: string) => void;
   pushMarker: (key: string, marker: Marker) => void;
@@ -115,15 +122,15 @@ export interface BaseMapInterface {
 var baseMapMethods: BaseMapInterface | undefined = undefined;
 
 // There really has to be a better way to do this, but we only ever have 1 base map so I guess it works.
-export function getBaseMap() {
+export function getBaseMap(): BaseMapInterface | undefined {
   return baseMapMethods;
 }
 
 export default defineComponent({
   name: 'BaseMap',
   data: function (): {
-    flyToLocation: { center: LngLatLike; zoom: number } | undefined;
-    boundsToFit: LngLatBoundsLike | undefined;
+    flyToLocation?: { center: LngLatLike; zoom?: number };
+    boundsToFit?: LngLatBoundsLike;
     markers: Map<string, Marker>;
     layers: string[];
     loaded: boolean;
@@ -290,17 +297,30 @@ export default defineComponent({
         map.getCanvas().style.cursor = value;
       });
     },
-    flyTo: async function (location: LngLatLike, zoom: number): Promise<void> {
+    flyToPlace(place: Place): void {
+      if (place.bbox) {
+        // prefer bounds when available so we don't "overzoom" on a large
+        // entity like an entire city.
+        this.fitBounds(place.bbox, { maxZoom: 16 });
+      } else {
+        this.flyTo(place.point, 16);
+      }
+    },
+    flyTo: function (location: LngLatLike, zoom?: number): void {
       if (this.loaded) {
-        map?.flyTo({ center: location, zoom: zoom }, { flying: true });
+        let flyToOptions: FlyToOptions = { center: location };
+        if (zoom) {
+          flyToOptions.zoom = zoom;
+        }
+        map?.flyTo(flyToOptions, { flying: true });
       } else {
         this.$data.flyToLocation = { center: location, zoom: zoom };
       }
     },
-    fitBounds: async function (
+    fitBounds: function (
       bounds: LngLatBoundsLike,
       options: FitBoundsOptions = {}
-    ) {
+    ): void {
       const defaultOptions = {
         padding: Math.min(window.innerWidth, window.innerHeight) / 8,
       };
@@ -343,7 +363,11 @@ export default defineComponent({
     let map = await loadMap();
     // This might be the ugliest thing in this whole web app. Expose methods through an internal thing.
     baseMapMethods = {
+      getCenter: () => map.getCenter(),
+      getBounds: () => map.getBounds(),
+      getZoom: () => map.getZoom(),
       setCursor: this.setCursor,
+      flyToPlace: this.flyToPlace,
       flyTo: this.flyTo,
       fitBounds: this.fitBounds,
       pushMarker: this.pushMarker,
@@ -494,15 +518,4 @@ export default defineComponent({
     });
   },
 });
-
-export function sourceMarker(): Marker {
-  let element = document.createElement('div');
-  element.innerHTML =
-    '<svg display="block" height="20" width="20"><circle cx="10" cy="10" r="7" stroke="#111" stroke-width="2" fill="white" /></svg>';
-  return new Marker({ element });
-}
-
-export function destinationMarker(): Marker {
-  return new Marker({ color: '#111111' });
-}
 </script>

--- a/web/frontend/src/components/BaseMap.vue
+++ b/web/frontend/src/components/BaseMap.vue
@@ -126,6 +126,11 @@ export function getBaseMap(): BaseMapInterface | undefined {
   return baseMapMethods;
 }
 
+let baseMapPromiseResolver: (baseMap: BaseMapInterface) => void;
+export const baseMapPromise = new Promise<BaseMapInterface>((resolver) => {
+  baseMapPromiseResolver = resolver;
+});
+
 export default defineComponent({
   name: 'BaseMap',
   data: function (): {
@@ -515,6 +520,10 @@ export default defineComponent({
           }
         }
       }
+      if (!baseMapMethods) {
+        throw new Error('baseMapMethods must remain set');
+      }
+      baseMapPromiseResolver(baseMapMethods);
     });
   },
 });

--- a/web/frontend/src/components/SearchListItem.vue
+++ b/web/frontend/src/components/SearchListItem.vue
@@ -1,0 +1,31 @@
+<template>
+  <q-item class="list-item" active-class="list-item--selected" :active="active">
+    <q-item-section>
+      <q-item-label>
+        {{ place.name }}
+      </q-item-label>
+      <q-item-label class="text-weight-light">
+        {{ place.address }}
+      </q-item-label>
+      <travel-mode-bar :to-place="place" :hidden="!active" class="q-mt-sm" />
+    </q-item-section>
+  </q-item>
+</template>
+
+<script lang="ts">
+import Place from 'src/models/Place';
+import TravelModeBar from 'src/components/TravelModeBar.vue';
+import { defineComponent, PropType } from 'vue';
+
+export default defineComponent({
+  name: 'SearchListItem',
+  components: { TravelModeBar },
+  props: {
+    place: {
+      type: Object as PropType<Place>,
+      required: true,
+    },
+    active: Boolean,
+  },
+});
+</script>

--- a/web/frontend/src/components/TripListItem.vue
+++ b/web/frontend/src/components/TripListItem.vue
@@ -1,8 +1,8 @@
 <template>
   <q-item
-    class="trip-list-item"
+    class="list-item"
     :clickable="!$props.active"
-    active-class="trip-list-item--selected"
+    active-class="list-item--selected"
     :active="$props.active"
     v-on:click="$props.clickHandler"
   >
@@ -19,18 +19,6 @@
     </q-item-section>
   </q-item>
 </template>
-
-<style lang="scss">
-.trip-list-item {
-  border-bottom: solid $separator 1px;
-  padding: 16px;
-}
-
-.trip-list-item--selected {
-  border-left: solid $accent 8px;
-  padding-left: 8px;
-}
-</style>
 
 <script lang="ts">
 import { defineComponent } from 'vue';

--- a/web/frontend/src/components/TripSearch.vue
+++ b/web/frontend/src/components/TripSearch.vue
@@ -4,7 +4,7 @@
       <search-box
         :hint="$t('search.from')"
         :style="{ flex: 1 }"
-        :force-place="fromPlace"
+        :initial-place="fromPlace"
         v-on:did-select-place="didSelectFromPlace"
       />
       <q-btn
@@ -21,7 +21,7 @@
       <search-box
         :hint="$t('search.to')"
         :style="{ flex: 1 }"
-        :force-place="toPlace"
+        :initial-place="toPlace"
         v-on:did-select-place="didSelectToPlace"
       />
       <q-btn

--- a/web/frontend/src/components/TripSearch.vue
+++ b/web/frontend/src/components/TripSearch.vue
@@ -4,7 +4,7 @@
       <search-box
         :hint="$t('search.from')"
         :style="{ flex: 1 }"
-        :force-text="fromPlace ? placeDisplayName(fromPlace) : ''"
+        :force-place="fromPlace"
         v-on:did-select-place="didSelectFromPlace"
       />
       <q-btn
@@ -21,7 +21,7 @@
       <search-box
         :hint="$t('search.to')"
         :style="{ flex: 1 }"
-        :force-text="toPlace ? placeDisplayName(toPlace) : ''"
+        :force-place="toPlace"
         v-on:did-select-place="didSelectToPlace"
       />
       <q-btn

--- a/web/frontend/src/css/app.scss
+++ b/web/frontend/src/css/app.scss
@@ -1,0 +1,9 @@
+.list-item {
+  border-bottom: solid $separator 1px;
+  padding: 16px;
+}
+
+.list-item--selected {
+  border-left: solid $accent 8px;
+  padding-left: 8px;
+}

--- a/web/frontend/src/models/Place.ts
+++ b/web/frontend/src/models/Place.ts
@@ -172,13 +172,30 @@ export default class Place {
     }
 
     const countryCode = feature.properties?.country_code;
-    console.assert(countryCode, 'no country code found for feature', feature);
+    const address = localizeAddress(feature.properties);
+
+    // This happens when searching for continent - e.g. "North America"
+    if (
+      feature.properties?.layer == 'continent' ||
+      feature.properties?.layer == 'empire'
+    ) {
+      console.assert(
+        !countryCode,
+        'expecting continent to have no countryCode',
+        feature
+      );
+      console.assert(
+        !address,
+        'expecting continent to have no address',
+        feature
+      );
+    } else {
+      console.assert(countryCode, 'no country code found for feature', feature);
+      console.assert(address, 'no address found for feature', feature);
+    }
 
     const name = feature.properties?.name;
     console.assert(name, 'no name found for feature', feature);
-
-    const address = localizeAddress(feature.properties);
-    console.assert(address, 'no address found for feature', feature);
 
     const place = new Place(id, location, bbox, countryCode, name, address);
     return place;

--- a/web/frontend/src/pages/AlternatesPage.vue
+++ b/web/frontend/src/pages/AlternatesPage.vue
@@ -57,11 +57,7 @@
 </style>
 
 <script lang="ts">
-import {
-  destinationMarker,
-  sourceMarker,
-  getBaseMap,
-} from 'src/components/BaseMap.vue';
+import { getBaseMap } from 'src/components/BaseMap.vue';
 import { Component, defineComponent, Ref, ref } from 'vue';
 import Place, { PlaceStorage } from 'src/models/Place';
 import { TravelMode } from 'src/utils/models';
@@ -74,6 +70,7 @@ import TripLayerId from 'src/models/TripLayerId';
 import Itinerary, { ItineraryErrorCode } from 'src/models/Itinerary';
 import { RouteErrorCode } from 'src/models/Route';
 import Prefs from 'src/utils/Prefs';
+import Markers from 'src/utils/Markers';
 
 export default defineComponent({
   name: 'AlternatesPage',
@@ -211,14 +208,14 @@ export default defineComponent({
       if (this.fromPlace) {
         map.pushMarker(
           'source_marker',
-          sourceMarker().setLngLat(this.fromPlace.point)
+          Markers.tripStart().setLngLat(this.fromPlace.point)
         );
       }
 
       if (this.toPlace) {
         map.pushMarker(
           'destination_marker',
-          destinationMarker().setLngLat(this.toPlace.point)
+          Markers.tripEnd().setLngLat(this.toPlace.point)
         );
       }
     },

--- a/web/frontend/src/pages/BaseMapPage.vue
+++ b/web/frontend/src/pages/BaseMapPage.vue
@@ -2,7 +2,10 @@
   <div class="top-card">
     <search-box
       v-on:did-select-place="searchBoxDidSelectPlace"
-      v-on:did-submit-search="searchBoxDidSubmitSearch"
+      v-on:did-submit-search="
+        (searchText) =>
+          $router.push(`/search/${encodeURIComponent(searchText)}`)
+      "
     />
   </div>
 </template>
@@ -55,9 +58,6 @@ export default defineComponent({
   name: 'BaseMapPage',
   components: { SearchBox },
   methods: {
-    searchBoxDidSubmitSearch(searchText: string) {
-      this.$router.push(`/search/${encodeURIComponent(searchText)}`);
-    },
     searchBoxDidSelectPlace(place?: Place) {
       if (place) {
         this.$router.push(`/place/${place.urlEncodedId()}`);

--- a/web/frontend/src/pages/BaseMapPage.vue
+++ b/web/frontend/src/pages/BaseMapPage.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="top-card">
-    <search-box v-on:did-select-place="searchBoxDidSelectPlace" />
+    <search-box
+      v-on:did-select-place="searchBoxDidSelectPlace"
+      v-on:did-submit-search="searchBoxDidSubmitSearch"
+    />
   </div>
 </template>
 
@@ -52,6 +55,9 @@ export default defineComponent({
   name: 'BaseMapPage',
   components: { SearchBox },
   methods: {
+    searchBoxDidSubmitSearch(searchText: string) {
+      this.$router.push(`/search/${encodeURIComponent(searchText)}`);
+    },
     searchBoxDidSelectPlace(place?: Place) {
       if (place) {
         this.$router.push(`/place/${place.urlEncodedId()}`);

--- a/web/frontend/src/pages/PlacePage.vue
+++ b/web/frontend/src/pages/PlacePage.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="top-card">
     <search-box
-      :force-text="place ? placeDisplayName(place) : undefined"
+      :force-place="place"
       v-on:did-select-place="searchBoxDidSelectPlace"
     />
   </div>

--- a/web/frontend/src/pages/PlacePage.vue
+++ b/web/frontend/src/pages/PlacePage.vue
@@ -12,13 +12,14 @@
 </template>
 
 <script lang="ts">
-import { LngLat, Marker } from 'maplibre-gl';
+import { LngLat } from 'maplibre-gl';
 import { getBaseMap } from 'src/components/BaseMap.vue';
 import { placeDisplayName } from 'src/i18n/utils';
 import PlaceCard from 'src/components/PlaceCard.vue';
 import { defineComponent } from 'vue';
 import SearchBox from 'src/components/SearchBox.vue';
 import Place, { PlaceId, PlaceStorage } from 'src/models/Place';
+import Markers from 'src/utils/Markers';
 
 function renderOnMap(place: Place) {
   const map = getBaseMap();
@@ -27,18 +28,9 @@ function renderOnMap(place: Place) {
     return;
   }
 
-  if (place.bbox) {
-    // prefer bounds when available so we don't "overzoom" on a large
-    // entity like an entire city.
-    map.fitBounds(place.bbox, { maxZoom: 16 });
-  } else {
-    map.flyTo(place.point, 16);
-  }
+  map.flyToPlace(place);
 
-  map.pushMarker(
-    'active_marker',
-    new Marker({ color: '#111111' }).setLngLat(place.point)
-  );
+  map.pushMarker('active_marker', Markers.active().setLngLat(place.point));
   map.removeAllLayers();
   map.removeMarkersExcept(['active_marker']);
 }

--- a/web/frontend/src/pages/PlacePage.vue
+++ b/web/frontend/src/pages/PlacePage.vue
@@ -1,8 +1,12 @@
 <template>
   <div class="top-card">
     <search-box
-      :force-place="place"
+      :initial-place="place"
       v-on:did-select-place="searchBoxDidSelectPlace"
+      v-on:did-submit-search="
+        (searchText) =>
+          $router.push(`/search/${encodeURIComponent(searchText)}`)
+      "
     />
   </div>
 

--- a/web/frontend/src/pages/SearchPage.vue
+++ b/web/frontend/src/pages/SearchPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="top-card">
     <search-box
-      :force-text="searchText"
+      :initial-input-text="searchText"
       :results-callback="searchBoxDidUpdateResults"
       v-on:did-select-place="searchBoxDidSelectPlace"
       v-on:did-submit-search="searchBoxDidSubmitSearch"
@@ -26,7 +26,7 @@
 </template>
 
 <script lang="ts">
-import { getBaseMap } from 'src/components/BaseMap.vue';
+import { baseMapPromise, getBaseMap } from 'src/components/BaseMap.vue';
 import SearchBox from 'src/components/SearchBox.vue';
 import SearchListItem from 'src/components/SearchListItem.vue';
 import Place, { PlaceId } from 'src/models/Place';
@@ -62,10 +62,7 @@ export default defineComponent({
     },
     searchBoxDidSelectPlace(place?: Place): void {
       if (place) {
-        console.assert(
-          false,
-          'this method is (currently) only called when clearing the text field'
-        );
+        this.$router.push(`/place/${place.urlEncodedId()}`);
       } else {
         // User "cleared" search field
         this.$router.push('/');
@@ -127,11 +124,7 @@ export default defineComponent({
         return;
       }
 
-      let map = getBaseMap();
-      if (!map) {
-        console.error('map was unexpectedly unset');
-        return;
-      }
+      let map = await baseMapPromise;
 
       let focus = undefined;
       if (map.getZoom() > 6) {
@@ -203,12 +196,8 @@ export default defineComponent({
   mounted(): void {
     this.updateSearch(this.searchText);
   },
-  unmounted(): void {
-    const map = getBaseMap();
-    if (!map) {
-      console.error('map was unexpectedly unset');
-      return;
-    }
+  async unmounted(): Promise<void> {
+    const map = await baseMapPromise;
     this.placeChoices = [];
     map.removeAllMarkers();
   },

--- a/web/frontend/src/pages/SearchPage.vue
+++ b/web/frontend/src/pages/SearchPage.vue
@@ -2,7 +2,6 @@
   <div class="top-card">
     <search-box
       :initial-input-text="searchText"
-      :results-callback="searchBoxDidUpdateResults"
       v-on:did-select-place="searchBoxDidSelectPlace"
       v-on:did-submit-search="searchBoxDidSubmitSearch"
     />
@@ -67,10 +66,6 @@ export default defineComponent({
         // User "cleared" search field
         this.$router.push('/');
       }
-    },
-    searchBoxDidUpdateResults(places?: Place[]) {
-      this.placeChoices = places ?? [];
-      this.renderPlacesOnMap();
     },
     searchBoxDidClearSearch() {
       this.$router.push('/');

--- a/web/frontend/src/pages/SearchPage.vue
+++ b/web/frontend/src/pages/SearchPage.vue
@@ -1,0 +1,216 @@
+<template>
+  <div class="top-card">
+    <search-box
+      :force-text="searchText"
+      :results-callback="searchBoxDidUpdateResults"
+      v-on:did-select-place="searchBoxDidSelectPlace"
+      v-on:did-submit-search="searchBoxDidSubmitSearch"
+    />
+  </div>
+
+  <div class="bottom-card">
+    <q-list>
+      <search-list-item
+        v-for="place in placeChoices"
+        v-bind:key="place.id.serialized()"
+        :place="place"
+        :active="place == selectedPlace"
+        clickable
+        :id="`search-list-item-${place.id.serialized()}`"
+        v-on:mouseenter="didHoverSearchListItem(place)"
+        v-on:mouseleave="didHoverSearchListItem(undefined)"
+        v-on:click="didClickSearchListItem(place)"
+      />
+    </q-list>
+  </div>
+</template>
+
+<script lang="ts">
+import { getBaseMap } from 'src/components/BaseMap.vue';
+import SearchBox from 'src/components/SearchBox.vue';
+import SearchListItem from 'src/components/SearchListItem.vue';
+import Place, { PlaceId } from 'src/models/Place';
+import PeliasClient from 'src/services/PeliasClient';
+import Markers from 'src/utils/Markers';
+import { supportsHover } from 'src/utils/misc';
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'SearchPage',
+  props: {
+    searchText: {
+      type: String,
+      required: true,
+    },
+  },
+  data(): {
+    placeChoices: Place[];
+    selectedPlace?: Place;
+    hoveredPlace?: Place;
+  } {
+    return {
+      placeChoices: [],
+      selectedPlace: undefined,
+      hoveredPlace: undefined,
+    };
+  },
+  components: { SearchBox, SearchListItem },
+  methods: {
+    searchBoxDidSubmitSearch(searchText: string): void {
+      this.updateSearch(searchText);
+      this.$router.push(`/search/${encodeURIComponent(searchText)}`);
+    },
+    searchBoxDidSelectPlace(place?: Place): void {
+      if (place) {
+        console.assert(
+          false,
+          'this method is (currently) only called when clearing the text field'
+        );
+      } else {
+        // User "cleared" search field
+        this.$router.push('/');
+      }
+    },
+    searchBoxDidUpdateResults(places?: Place[]) {
+      this.placeChoices = places ?? [];
+      this.renderPlacesOnMap();
+    },
+    searchBoxDidClearSearch() {
+      this.$router.push('/');
+    },
+    didClickSearchListItem(place: Place): void {
+      this.selectedPlace = place;
+      this.renderPlacesOnMap();
+      let map = getBaseMap();
+      if (!map) {
+        console.error('map was unexpectedly nil');
+        return;
+      }
+      map.flyToPlace(place);
+    },
+    didHoverSearchListItem(place?: Place): void {
+      if (!supportsHover()) {
+        // FIX: selecting autocomplete item on mobile requires double
+        // tapping.
+        //
+        // On touch devices, where hover is not supported, this method is
+        // fired upon tapping. I don't fully understand why, but maybe
+        // mutating the state in this method would rebuild the component,
+        // canceling any outstanding event handlers on the old component.
+        return;
+      }
+      this.hoveredPlace = place;
+      this.renderPlacesOnMap();
+    },
+    didClickPlaceMarker(place: Place): void {
+      this.selectedPlace = place;
+      this.renderPlacesOnMap();
+      const searchListItem = document.getElementById(
+        `search-list-item-${place.id.serialized()}`
+      );
+      if (searchListItem) {
+        // This is async because we want to scroll after re-rendering the
+        // "selected" cell, which is slightly larger.
+        // Otherwise, if we scroll before the cell is re-rendered, it's new size
+        // might be slightly out of view.
+        setTimeout(() =>
+          searchListItem.scrollIntoView({
+            behavior: 'smooth',
+            block: 'nearest',
+          })
+        );
+      }
+    },
+    async updateSearch(searchText: string): Promise<void> {
+      if (searchText.length == 0) {
+        this.placeChoices = [];
+        return;
+      }
+
+      let map = getBaseMap();
+      if (!map) {
+        console.error('map was unexpectedly unset');
+        return;
+      }
+
+      let focus = undefined;
+      if (map.getZoom() > 6) {
+        focus = map.getCenter();
+      }
+
+      let places: Place[] = [];
+      try {
+        // The search endpoint results are worse for categorical searches like "coffee"
+        // See: https://github.com/pelias/pelias/issues/938
+        // const results = await PeliasClient.search(searchText, focus);
+        //
+        // So for now we're using autocomplete. Otherwise I think it's too weird
+        // to show such different results.
+        const results = await PeliasClient.autocomplete(searchText, focus);
+        if (!results.bbox) {
+          console.error('search results missing bounding box');
+        } else if (results.bbox.length != 4) {
+          console.error('unexpected bbox dimensions');
+        } else {
+          map.fitBounds(results.bbox);
+        }
+
+        for (const feature of results.features) {
+          if (!feature.properties?.gid) {
+            console.error('feature was missing gid');
+            continue;
+          }
+          let gid = feature.properties.gid;
+          let id = PlaceId.gid(gid);
+          places.push(Place.fromFeature(id, feature));
+        }
+      } catch (e) {
+        console.warn('error with autocomplete', e);
+      }
+
+      this.placeChoices = places;
+      this.renderPlacesOnMap();
+    },
+    renderPlacesOnMap() {
+      const map = getBaseMap();
+      if (!map) {
+        console.error('basemap was unexpectedly unset');
+        return;
+      }
+
+      map.removeAllMarkers();
+      this.placeChoices.forEach((place: Place, idx: number) => {
+        if (place == this.selectedPlace || place == this.hoveredPlace) {
+          return;
+        }
+        const marker = Markers.inactive().setLngLat(place.point);
+        marker.getElement().addEventListener('click', () => {
+          this.didClickPlaceMarker(place);
+        });
+        map.pushMarker(`place_${idx}`, marker);
+      });
+
+      if (this.selectedPlace) {
+        const marker = Markers.active().setLngLat(this.selectedPlace.point);
+        map.pushMarker('selected_place', marker);
+      }
+      if (this.hoveredPlace) {
+        const marker = Markers.active().setLngLat(this.hoveredPlace.point);
+        map.pushMarker('hovered_place', marker);
+      }
+    },
+  },
+  mounted(): void {
+    this.updateSearch(this.searchText);
+  },
+  unmounted(): void {
+    const map = getBaseMap();
+    if (!map) {
+      console.error('map was unexpectedly unset');
+      return;
+    }
+    this.placeChoices = [];
+    map.removeAllMarkers();
+  },
+});
+</script>

--- a/web/frontend/src/pages/SearchPage.vue
+++ b/web/frontend/src/pages/SearchPage.vue
@@ -57,7 +57,7 @@ export default defineComponent({
   methods: {
     searchBoxDidSubmitSearch(searchText: string): void {
       this.updateSearch(searchText);
-      this.$router.push(`/search/${encodeURIComponent(searchText)}`);
+      this.$router.replace(`/search/${encodeURIComponent(searchText)}`);
     },
     searchBoxDidSelectPlace(place?: Place): void {
       if (place) {
@@ -66,9 +66,6 @@ export default defineComponent({
         // User "cleared" search field
         this.$router.push('/');
       }
-    },
-    searchBoxDidClearSearch() {
-      this.$router.push('/');
     },
     didClickSearchListItem(place: Place): void {
       this.selectedPlace = place;

--- a/web/frontend/src/pages/StepsPage.vue
+++ b/web/frontend/src/pages/StepsPage.vue
@@ -34,11 +34,7 @@
 </style>
 
 <script lang="ts">
-import {
-  destinationMarker,
-  getBaseMap,
-  sourceMarker,
-} from 'src/components/BaseMap.vue';
+import { getBaseMap } from 'src/components/BaseMap.vue';
 import { TravelMode, DistanceUnits } from 'src/utils/models';
 import Place, { PlaceStorage } from 'src/models/Place';
 import { defineComponent, Component, Ref, ref } from 'vue';
@@ -47,6 +43,7 @@ import SingleModeSteps from 'src/components/SingleModeSteps.vue';
 import MultiModalSteps from 'src/components/MultiModalSteps.vue';
 import SearchBox from 'src/components/SearchBox.vue';
 import TripLayerId from 'src/models/TripLayerId';
+import Markers from 'src/utils/Markers';
 
 export default defineComponent({
   name: 'StepsPage',
@@ -190,14 +187,14 @@ export default defineComponent({
     if (this.fromPlace) {
       map.pushMarker(
         'source_marker',
-        sourceMarker().setLngLat(this.fromPlace.point)
+        Markers.tripStart().setLngLat(this.fromPlace.point)
       );
     }
 
     if (this.toPlace) {
       map.pushMarker(
         'destination_marker',
-        destinationMarker().setLngLat(this.toPlace.point)
+        Markers.tripEnd().setLngLat(this.toPlace.point)
       );
     }
   },

--- a/web/frontend/src/pages/StepsPage.vue
+++ b/web/frontend/src/pages/StepsPage.vue
@@ -8,13 +8,13 @@
         <search-box
           :hint="$t('search.from')"
           :style="{ flex: 1 }"
-          :force-text="fromPlace?.name"
+          :force-place="fromPlace"
           readonly
         />
         <search-box
           :hint="$t('search.to')"
           :style="{ flex: 1 }"
-          :force-text="toPlace?.name"
+          :force-place="toPlace"
           readonly
         />
       </div>

--- a/web/frontend/src/pages/StepsPage.vue
+++ b/web/frontend/src/pages/StepsPage.vue
@@ -8,13 +8,13 @@
         <search-box
           :hint="$t('search.from')"
           :style="{ flex: 1 }"
-          :force-place="fromPlace"
+          :initial-place="fromPlace"
           readonly
         />
         <search-box
           :hint="$t('search.to')"
           :style="{ flex: 1 }"
-          :force-place="toPlace"
+          :initial-place="toPlace"
           readonly
         />
       </div>

--- a/web/frontend/src/router/routes.ts
+++ b/web/frontend/src/router/routes.ts
@@ -27,6 +27,18 @@ const routes: RouteRecordRaw[] = [
     ],
   },
   {
+    path: '/search/:searchText',
+    component: () => import('layouts/MainLayout.vue'),
+    children: [
+      {
+        name: 'search',
+        path: '/search/:searchText',
+        props: true,
+        component: () => import('pages/SearchPage.vue'),
+      },
+    ],
+  },
+  {
     path: '/directions/:mode/:to',
     component: () => import('layouts/MainLayout.vue'),
     children: [

--- a/web/frontend/src/services/PeliasClient.ts
+++ b/web/frontend/src/services/PeliasClient.ts
@@ -1,8 +1,26 @@
 import { LngLat } from 'maplibre-gl';
 
 type PlaceResponse = GeoJSON.FeatureCollection;
+type AutocompleteResponse = GeoJSON.FeatureCollection;
 
 export default class PeliasClient {
+  static async autocomplete(
+    text: string,
+    focus?: LngLat
+  ): Promise<AutocompleteResponse> {
+    let url = `/pelias/v1/autocomplete?text=${encodeURIComponent(text)}`;
+    if (focus) {
+      url += `&focus.point.lon=${focus.lng}&focus.point.lat=${focus.lat}`;
+    }
+    const response = await fetch(url);
+
+    if (response.ok) {
+      return await response.json();
+    } else {
+      throw new Error(`error response from pelias: ${response}`);
+    }
+  }
+
   static async findByGid(gid: string): Promise<PlaceResponse> {
     const response = await fetch(`/pelias/v1/place?ids=${gid}`);
     if (response.ok) {

--- a/web/frontend/src/services/PeliasClient.ts
+++ b/web/frontend/src/services/PeliasClient.ts
@@ -40,4 +40,27 @@ export default class PeliasClient {
       throw new Error(`error response from pelias: ${response}`);
     }
   }
+
+  // This endpoint is unused for now. The results are very different and (in my
+  // estimation) worse in some cases, so we only use the "autocomplete" search
+  // for now.
+  //
+  // See https://github.com/pelias/pelias/issues/938
+  static async search(
+    text: string,
+    focus?: LngLat
+  ): Promise<AutocompleteResponse> {
+    let url = `/pelias/v1/search?text=${encodeURIComponent(text)}`;
+    if (focus) {
+      url += `&focus.point.lon=${focus.lng}&focus.point.lat=${focus.lat}`;
+    }
+
+    const response = await fetch(url);
+
+    if (response.ok) {
+      return await response.json();
+    } else {
+      throw new Error(`error response from pelias: ${response}`);
+    }
+  }
 }

--- a/web/frontend/src/utils/Markers.ts
+++ b/web/frontend/src/utils/Markers.ts
@@ -1,0 +1,23 @@
+import { Marker } from 'maplibre-gl';
+
+export default {
+  active: (): Marker => {
+    const marker = new Marker({ color: '#111111' });
+    marker.getElement().classList.add('cursor-pointer');
+    return marker;
+  },
+  inactive: (): Marker => {
+    const marker = new Marker({ color: '#11111155' });
+    marker.getElement().classList.add('cursor-pointer');
+    return marker;
+  },
+  tripStart: (): Marker => {
+    const element = document.createElement('div');
+    element.innerHTML =
+      '<svg display="block" height="20" width="20"><circle cx="10" cy="10" r="7" stroke="#111" stroke-width="2" fill="white" /></svg>';
+    return new Marker({ element });
+  },
+  tripEnd: (): Marker => {
+    return new Marker({ color: '#111111' });
+  },
+};

--- a/web/frontend/src/utils/misc.ts
+++ b/web/frontend/src/utils/misc.ts
@@ -1,0 +1,3 @@
+export function supportsHover(): boolean {
+  return window.matchMedia('(hover: hover)').matches;
+}


### PR DESCRIPTION
You can now press enter to see all the search results rendered on the map at once.

https://user-images.githubusercontent.com/217057/216727334-ee015e81-d2da-4a77-ba2d-4115b078d126.mp4

There's plenty more to do to improve this (like pagination to "see more" more results!).

There were a couple of diversions while implementing this though, and I figure this is strictly better than what was there before, so I'm going to merge it without the following:

1. I initially assumed I'd want to use Pelias's "search" endpoint rather than the "autocomplete" endpoint, but I'm not convinced. The results are pretty different in some cases, and it's pretty strange to see a completely different set of results after hitting enter vs. what you were seeing in the autocomplete. See https://github.com/pelias/pelias/issues/938

2. I foolishly tried to use this as an opportunity to overhaul the SearchBox widget - adopting Quasar's QSelect widget, instead of the QInput we'd been using. QSelect has some advantages, but also some drawbacks. In the interest of monotonic improvement, I reverted the QSelect changes in 7f0f396da39ee775b78bc8b436f75ce7c88b0a3e