### PR TITLE
[k8s] speed up larger OTP zones

### DIFF
--- a/k8s/_template/opentripplanner-AREA-deployment.yaml.tpl
+++ b/k8s/_template/opentripplanner-AREA-deployment.yaml.tpl
@@ -33,6 +33,10 @@ spec:
       containers:
         - name: main
           image: ghcr.io/headwaymaps/opentripplanner:${HEADWAY_CONTAINER_TAG}
+          env:
+            name: "JAVA_OPTS"
+            # It makes to keep this in sync to be just under the resources.limits.memory
+            value: "-Xmx 4G"
           imagePullPolicy: Always
           ports:
             - containerPort: 8000
@@ -41,7 +45,8 @@ spec:
               mountPath: /var/opentripplanner
           resources:
             limits:
-              memory: 4.5Gi
+              # It makes to keep this in sync to be just above env.JAVA_OPTS.-Xmx
+              memory: 4.2Gi
             requests:
               memory: 500Mi
           livenessProbe:

--- a/k8s/configs/planet-dev/opentripplanner-losangeles-deployment.yaml
+++ b/k8s/configs/planet-dev/opentripplanner-losangeles-deployment.yaml
@@ -33,6 +33,10 @@ spec:
       containers:
         - name: main
           image: ghcr.io/headwaymaps/opentripplanner:dev
+          env:
+            name: "JAVA_OPTS"
+            # It makes to keep this in sync to be just under the resources.limits.memory
+            value: "-Xmx 4G"
           imagePullPolicy: Always
           ports:
             - containerPort: 8000
@@ -41,7 +45,8 @@ spec:
               mountPath: /var/opentripplanner
           resources:
             limits:
-              memory: 4.5Gi
+              # It makes to keep this in sync to be just above env.JAVA_OPTS.-Xmx
+              memory: 4.2Gi
             requests:
               memory: 500Mi
           livenessProbe:

--- a/k8s/configs/planet-dev/opentripplanner-seattle-deployment.yaml
+++ b/k8s/configs/planet-dev/opentripplanner-seattle-deployment.yaml
@@ -33,6 +33,10 @@ spec:
       containers:
         - name: main
           image: ghcr.io/headwaymaps/opentripplanner:dev
+          env:
+            name: "JAVA_OPTS"
+            # It makes to keep this in sync to be just under the resources.limits.memory
+            value: "-Xmx 4G"
           imagePullPolicy: Always
           ports:
             - containerPort: 8000
@@ -41,7 +45,8 @@ spec:
               mountPath: /var/opentripplanner
           resources:
             limits:
-              memory: 4.5Gi
+              # It makes to keep this in sync to be just above env.JAVA_OPTS.-Xmx
+              memory: 4.2Gi
             requests:
               memory: 500Mi
           livenessProbe:

--- a/k8s/configs/planet/opentripplanner-losangeles-deployment.yaml
+++ b/k8s/configs/planet/opentripplanner-losangeles-deployment.yaml
@@ -33,6 +33,10 @@ spec:
       containers:
         - name: main
           image: ghcr.io/headwaymaps/opentripplanner:latest
+          env:
+            name: "JAVA_OPTS"
+            # It makes to keep this in sync to be just under the resources.limits.memory
+            value: "-Xmx 4G"
           imagePullPolicy: Always
           ports:
             - containerPort: 8000
@@ -41,7 +45,8 @@ spec:
               mountPath: /var/opentripplanner
           resources:
             limits:
-              memory: 4.5Gi
+              # It makes to keep this in sync to be just above env.JAVA_OPTS.-Xmx
+              memory: 4.2Gi
             requests:
               memory: 500Mi
           livenessProbe:

--- a/k8s/configs/planet/opentripplanner-seattle-deployment.yaml
+++ b/k8s/configs/planet/opentripplanner-seattle-deployment.yaml
@@ -33,6 +33,10 @@ spec:
       containers:
         - name: main
           image: ghcr.io/headwaymaps/opentripplanner:latest
+          env:
+            name: "JAVA_OPTS"
+            # It makes to keep this in sync to be just under the resources.limits.memory
+            value: "-Xmx 4G"
           imagePullPolicy: Always
           ports:
             - containerPort: 8000
@@ -41,7 +45,8 @@ spec:
               mountPath: /var/opentripplanner
           resources:
             limits:
-              memory: 4.5Gi
+              # It makes to keep this in sync to be just above env.JAVA_OPTS.-Xmx
+              memory: 4.2Gi
             requests:
               memory: 500Mi
           livenessProbe:

--- a/k8s/configs/seattle-dev/opentripplanner-seattle-deployment.yaml
+++ b/k8s/configs/seattle-dev/opentripplanner-seattle-deployment.yaml
@@ -33,6 +33,10 @@ spec:
       containers:
         - name: main
           image: ghcr.io/headwaymaps/opentripplanner:dev
+          env:
+            name: "JAVA_OPTS"
+            # It makes to keep this in sync to be just under the resources.limits.memory
+            value: "-Xmx 4G"
           imagePullPolicy: Always
           ports:
             - containerPort: 8000
@@ -41,7 +45,8 @@ spec:
               mountPath: /var/opentripplanner
           resources:
             limits:
-              memory: 4.5Gi
+              # It makes to keep this in sync to be just above env.JAVA_OPTS.-Xmx
+              memory: 4.2Gi
             requests:
               memory: 500Mi
           livenessProbe:


### PR DESCRIPTION
Java heap should be allowed to more or less fill the container limits.