### PR TITLE
avoid confusing error when serving stale assets

### DIFF
--- a/.github/workflows/push-dev-containers.yml
+++ b/.github/workflows/push-dev-containers.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: earthly/actions-setup@v1
         with:
-          version: "latest"
+          version: "0.7.1"
       - uses: actions/checkout@v2
       - name: Docker login
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u headwaymaps --password-stdin

--- a/.github/workflows/push-latest-containers.yml
+++ b/.github/workflows/push-latest-containers.yml
@@ -12,7 +12,8 @@ jobs:
     steps:
       - uses: earthly/actions-setup@v1
         with:
-          version: "latest"
+          # pinning to `latest` requires using the GH API, which causes spurious rate limiting errors
+          version: "0.7.1"
       - uses: actions/checkout@v2
       - name: Docker login
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u headwaymaps --password-stdin

--- a/services/frontend/nginx.conf.template
+++ b/services/frontend/nginx.conf.template
@@ -43,10 +43,22 @@ http {
 
     location /static/  {
       alias ${HEADWAY_SHARED_VOL}/;
+      expires 5m;
+      add_header Cache-Control "public";
     }
 
     location / {
       try_files ${ESC}uri /index.html;
+      # Short lived cache for non-asset pages
+      expires 5m;
+      add_header Cache-Control "public";
+    }
+
+    location ~* \.(?:css|js|jpg|svg)$ {
+      expires 30d;
+      # We aggressively cache assets, since our asset URLs contain a
+      # cache-buster
+      add_header Cache-Control "public";
     }
   }
 }


### PR DESCRIPTION
For our SPA to work, we route all requests for which a file can't be found, to index.html - assuming it's a page request that the js app router will handle.
    
But when the user loads from cache a stale index.html (from a previous deploy), we'll request assets, which include a stale cache-buster (like style.ab123.css). These should 404, but instead are hitting the fallback rule and are served the content of index.html - which results in a weird content-type error (expecting javascript, but receiving html).
    
So we now have a special rule for css/js assets - preventing them from being served the SPA app. 

We also mark assets for aggressive caching since they are immutable and set a pretty conservative cache for everything else.