### PR TITLE
improve search bar layout and add keyboard navigation

### DIFF
--- a/services/frontend/www-app/src/components/SearchBox.vue
+++ b/services/frontend/www-app/src/components/SearchBox.vue
@@ -34,10 +34,10 @@
     >
       <q-list>
         <q-item
+          clickable
           :key="place.serializedId()"
           v-for="(place, index) in placeChoices"
           :class="index == highlightedIndex ? 'highlighted' : ''"
-          clickable
           v-on:click="selectPlace(place)"
           v-on:mouseenter="hoverPlace(place)"
           v-on:mouseleave="hoverPlace(undefined)"
@@ -85,7 +85,6 @@
     .q-item {
       padding-left: 8px;
       padding-right: 8px;
-      cursor: pointer;
     }
 
     .q-item.highlighted {

--- a/services/frontend/www-app/src/components/SearchBox.vue
+++ b/services/frontend/www-app/src/components/SearchBox.vue
@@ -9,6 +9,7 @@
         :readonly="readonly"
         :debounce="0"
         :dense="true"
+        type="search"
         @blur="onBlur"
         @input="onInput"
         @keydown="onKeyDown"
@@ -25,24 +26,11 @@
         @click="clear()"
       />
     </div>
-    <q-menu
-      square
-      fit
-      auto-close
+    <div
       ref="autoCompleteMenu"
-      :no-focus="true"
-      :no-refocus="true"
+      class="auto-complete-menu"
       v-on:before-hide="removeHoverMarkers"
-      @show="menuShowing = true"
-      @hide="menuShowing = false"
-      :target="(($refs.autoCompleteInput as Element)?.parentNode as Element)"
-      :style="{
-        border: 'solid black 2px',
-        'border-top': 'none',
-        'border-radius': '0 0 4px 4px',
-        opacity: (placeChoices?.length ?? 0) == 0 ? 0 : 1,
-      }"
-      :offset="[0, 0]"
+      :hidden="!(placeChoices && placeChoices.length > 0)"
     >
       <q-list>
         <q-item
@@ -61,22 +49,38 @@
           </q-item-section>
         </q-item>
       </q-list>
-    </q-menu>
+    </div>
   </div>
 </template>
 
 <style lang="scss">
 .search-box {
-  border: solid black 1px;
+  border: solid #aaa 1px;
   border-radius: 4px;
   background-color: white;
-  padding: 4px 8px;
 
-  &:has(input:focus) {
-    box-shadow: 0 0 2px 1px black;
+  .auto-complete-menu {
+    display: none;
+
+    .q-item:first-child {
+      border-top: solid #aaa 1px;
+    }
+    .q-item {
+      padding-left: 8px;
+      padding-right: 8px;
+    }
+  }
+
+  &:focus-within {
+    box-shadow: 0 0 2px 1px #666;
+
+    .auto-complete-menu {
+      display: block;
+    }
   }
 
   .input-field {
+    padding: 4px 8px;
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -88,9 +92,6 @@
 
     input:focus {
       outline: none;
-    }
-
-    button.clear-btn {
     }
   }
 }
@@ -166,8 +167,10 @@ export default defineComponent({
       return this.$refs.autoCompleteInput as HTMLInputElement;
     },
     clear(): void {
+      this.inputText = '';
       this.selectPlace(undefined);
-      this.autoCompleteInput().value = '';
+      this.placeChoices = undefined;
+      this.autoCompleteInput().focus();
     },
   },
   watch: {
@@ -284,16 +287,9 @@ export default defineComponent({
       placeChoices,
       placeHovered,
       mostRecentSearchIdx,
-      deferHide(menu: QMenu) {
-        setTimeout(() => {
-          menu.hide();
-          removeHoverMarkers();
-        }, 500);
-      },
       removeHoverMarkers,
       updateAutocomplete(menu: QMenu) {
         console.log('updateAutocomplete. menu:', menu);
-        menu.show();
         if (placeHovered.value) {
           placeHovered.value = undefined;
         }

--- a/services/frontend/www-app/src/components/SearchBox.vue
+++ b/services/frontend/www-app/src/components/SearchBox.vue
@@ -6,11 +6,7 @@
         :tabindex="tabindex ?? 0"
         :placeholder="$props.hint || $t('where_to_question')"
         :value="inputText"
-        clearable
         :readonly="readonly"
-        :debounce="0"
-        :dense="true"
-        type="search"
         @blur="onBlur"
         @input="onInput"
         @keydown="onKeyDown"
@@ -112,6 +108,10 @@
     }
   }
 
+  &:has(input[readonly]) {
+    box-shadow: none;
+    border: dashed #aaa 1px;
+  }
   .input-field {
     font-size: 16px;
     padding: 4px 8px;
@@ -129,9 +129,11 @@
       outline: none;
     }
 
-    // only show clear-button when input is empty
-    &:has(input:placeholder-shown) .clear-button {
-      visibility: hidden;
+    // only show clear-button when input has content
+    // and is editable
+    &:has(input:placeholder-shown) .clear-button,
+    &:has(input[readonly]) .clear-button {
+      display: none;
     }
   }
 }
@@ -382,7 +384,7 @@ export default defineComponent({
       selectPlace(place?: Place) {
         ctx.emit('didSelectPlace', place);
         removeHoverMarkers();
-        // dimiss menu when a place is selected
+        // dismiss menu when a place is selected
         if (place) {
           let el = document.activeElement as HTMLElement;
           el.blur();

--- a/services/frontend/www-app/src/components/SearchBox.vue
+++ b/services/frontend/www-app/src/components/SearchBox.vue
@@ -67,8 +67,10 @@
     display: none;
     position: absolute;
     width: 100%;
+    max-height: 80vh;
 
     background-color: white;
+    overflow-y: scroll;
     border-top: none;
     border-radius: 0 0 4px 4px;
 
@@ -91,10 +93,6 @@
     }
 
     z-index: 1;
-
-    .q-item:first-child {
-      border-top: solid #ddd 1px;
-    }
   }
 
   &:focus-within {
@@ -103,6 +101,10 @@
     &:has(.auto-complete-menu .q-item:first-child) {
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
+    }
+
+    &:has(.auto-complete-menu .q-item:first-child) .input-field {
+      border-bottom: solid #ddd 1px;
     }
 
     .auto-complete-menu:has(.q-item) {

--- a/services/frontend/www-app/src/components/SearchBox.vue
+++ b/services/frontend/www-app/src/components/SearchBox.vue
@@ -1,32 +1,30 @@
 <template>
   <div class="search-box">
-    <q-input
-      ref="autoCompleteInput"
-      :label="$props.hint || $t('where_to_question')"
-      v-model="inputText"
-      clearable
-      :readonly="readonly"
-      :debounce="0"
-      :dense="true"
-      v-on:clear="selectPlace(undefined)"
-      v-on:blur="onBlur"
-      v-on:beforeinput="
-        () => {
-          if (isAndroid) {
-            updateAutocomplete(autoCompleteMenu());
-          }
-        }
-      "
-      v-on:update:model-value="
-        () => {
-          if (!isAndroid) {
-            updateAutocomplete(autoCompleteMenu());
-          }
-        }
-      "
-      v-on:keydown="onKeyDown"
-    >
-    </q-input>
+    <div class="input-field">
+      <input
+        ref="autoCompleteInput"
+        :placeholder="$props.hint || $t('where_to_question')"
+        :value="inputText"
+        clearable
+        :readonly="readonly"
+        :debounce="0"
+        :dense="true"
+        @blur="onBlur"
+        @input="onInput"
+        @keydown="onKeyDown"
+      />
+      <q-btn
+        round
+        dense
+        unelevated
+        padding="0"
+        class="clear-button"
+        icon="cancel"
+        color="transparent"
+        text-color="grey"
+        @click="clear()"
+      />
+    </div>
     <q-menu
       square
       fit
@@ -69,13 +67,31 @@
 
 <style lang="scss">
 .search-box {
-  border-radius: 4px 4px 0 0;
-  border: solid black 2px;
-  border-bottom: none;
-  padding: 4px;
+  border: solid black 1px;
+  border-radius: 4px;
   background-color: white;
-  .q-field--highlighted .q-field__control:before {
-    // border: solid blue 4px;
+  padding: 4px 8px;
+
+  &:has(input:focus) {
+    box-shadow: 0 0 2px 1px black;
+  }
+
+  .input-field {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    input {
+      flex: 1;
+      border: none;
+      background-color: transparent;
+    }
+
+    input:focus {
+      outline: none;
+    }
+
+    button.clear-btn {
+    }
   }
 }
 </style>
@@ -117,6 +133,10 @@ export default defineComponent({
         }
       }
     },
+    onInput(): void {
+      this.inputText = this.autoCompleteInput().value;
+      this.updateAutocomplete(this.autoCompleteMenu());
+    },
     onBlur(): void {
       if (Platform.is.ios) {
         // iOS (on at least 16.1) "helpfully" moves the focused input towards
@@ -142,8 +162,12 @@ export default defineComponent({
     autoCompleteMenu(): QMenu {
       return this.$refs.autoCompleteMenu as QMenu;
     },
-    autoCompleteInput(): QInput {
-      return this.$refs.autoCompleteInput as QInput;
+    autoCompleteInput(): HTMLInputElement {
+      return this.$refs.autoCompleteInput as HTMLInputElement;
+    },
+    clear(): void {
+      this.selectPlace(undefined);
+      this.autoCompleteInput().value = '';
     },
   },
   watch: {
@@ -268,6 +292,7 @@ export default defineComponent({
       },
       removeHoverMarkers,
       updateAutocomplete(menu: QMenu) {
+        console.log('updateAutocomplete. menu:', menu);
         menu.show();
         if (placeHovered.value) {
           placeHovered.value = undefined;

--- a/services/frontend/www-app/src/components/SearchBox.vue
+++ b/services/frontend/www-app/src/components/SearchBox.vue
@@ -175,7 +175,6 @@ export default defineComponent({
         this.highlightedIndex =
           (this.highlightedIndex + 1) % this.placeChoices.length;
       }
-      console.log('highlightedIndex', this.highlightedIndex);
     },
     highlightPrevious(): void {
       if (this.placeChoices.length == 0) {
@@ -190,10 +189,8 @@ export default defineComponent({
       } else {
         this.highlightedIndex = this.highlightedIndex - 1;
       }
-      console.log('highlightedIndex', this.highlightedIndex);
     },
     onKeyDown(event: KeyboardEvent): void {
-      console.log('pressed other key', event.key, event);
       if (event.key == 'Enter') {
         if (this.highlightedIndex != undefined) {
           const place = this.placeChoices[this.highlightedIndex];
@@ -381,7 +378,6 @@ export default defineComponent({
         updatePlaceChoices();
       },
       selectPlace(place?: Place) {
-        console.log('selected place', place);
         ctx.emit('didSelectPlace', place);
         removeHoverMarkers();
         // dimiss menu when a place is selected

--- a/services/frontend/www-app/src/components/SearchBox.vue
+++ b/services/frontend/www-app/src/components/SearchBox.vue
@@ -58,28 +58,23 @@
   position: relative;
 
   background-color: white;
-  border: solid #aaa 1px;
+
+  box-shadow: 0 0 2px 1px #666;
   border-radius: 4px;
 
   .auto-complete-menu {
     display: none;
     position: absolute;
-    // safari
-    width: calc(100% + 3px);
-    left: -1.5px;
-    // chrome
-    width: calc(100% + 2px);
-    left: -1px;
+    width: 100%;
 
     background-color: white;
-    border: solid #aaa 1px;
     border-top: none;
     border-radius: 0 0 4px 4px;
 
     // note the shadow is "brighter" than the shadow around the input text.
     // I'm not sure why this is required, but it matches better this way.
     // (tested on Safari and Chrome on macos)
-    box-shadow: 0 0 2px 1px #ccc;
+    box-shadow: 0 0 3px 2px #333;
 
     // prevent box shadow from casting "up" onto tex field
     clip-path: inset(0 -4px -4px -4px);
@@ -97,7 +92,7 @@
   }
 
   &:focus-within {
-    box-shadow: 0 0 3px 1px #aaa;
+    box-shadow: 0 0 3px 2px #222;
 
     &:has(.auto-complete-menu .q-item:first-child) {
       border-bottom-left-radius: 0;
@@ -110,8 +105,10 @@
   }
 
   .input-field {
+    font-size: 16px;
     padding: 4px 8px;
     display: flex;
+    height: 100%;
     flex-direction: row;
     align-items: center;
     input {
@@ -122,6 +119,11 @@
 
     input:focus {
       outline: none;
+    }
+
+    // only show clear-button when input is empty
+    &:has(input:placeholder-shown) .clear-button {
+      visibility: hidden;
     }
   }
 }

--- a/services/frontend/www-app/src/components/SearchBox.vue
+++ b/services/frontend/www-app/src/components/SearchBox.vue
@@ -62,19 +62,26 @@
   border-radius: 4px;
 
   .auto-complete-menu {
-    // display: none;
+    display: none;
     position: absolute;
+    // safari
     width: calc(100% + 3px);
     left: -1.5px;
+    // chrome
+    width: calc(100% + 2px);
+    left: -1px;
 
     background-color: white;
     border: solid #aaa 1px;
     border-top: none;
     border-radius: 0 0 4px 4px;
 
-    // box-shadow: offset-x | offset-y | blur-radius | spread-radius | color
-    box-shadow: 0 0 2px 1px #aaa;
-    // clip-path: inset(Tpx Rpx Bpx Lpx);
+    // note the shadow is "brighter" than the shadow around the input text.
+    // I'm not sure why this is required, but it matches better this way.
+    // (tested on Safari and Chrome on macos)
+    box-shadow: 0 0 2px 1px #ccc;
+
+    // prevent box shadow from casting "up" onto tex field
     clip-path: inset(0 -4px -4px -4px);
 
     .q-item {
@@ -89,7 +96,6 @@
     }
   }
 
-  box-shadow: 0 0 3px 1px #aaa;
   &:focus-within {
     box-shadow: 0 0 3px 1px #aaa;
 

--- a/services/frontend/www-app/src/components/SearchBox.vue
+++ b/services/frontend/www-app/src/components/SearchBox.vue
@@ -83,15 +83,17 @@
     .q-item {
       padding-left: 8px;
       padding-right: 8px;
+      cursor: pointer;
     }
+
     .q-item.highlighted {
-      background-color: yellow;
+      background-color: #ededed;
     }
 
     z-index: 1;
 
     .q-item:first-child {
-      border-top: solid #aaa 1px;
+      border-top: solid #ddd 1px;
     }
   }
 
@@ -192,6 +194,15 @@ export default defineComponent({
     onKeyDown(event: KeyboardEvent): void {
       console.log('pressed other key', event.key, event);
       if (event.key == 'Enter') {
+        if (this.highlightedIndex != undefined) {
+          const place = this.placeChoices[this.highlightedIndex];
+          if (!place) {
+            console.assert(false, 'missing place for highlightedIndex');
+            return;
+          }
+          this.selectPlace(place);
+          return;
+        }
         this.mostRecentSearchIdx++;
         let searchText = this.inputText;
         if (searchText) {
@@ -369,6 +380,7 @@ export default defineComponent({
         updatePlaceChoices();
       },
       selectPlace(place?: Place) {
+        console.log('selected place', place);
         ctx.emit('didSelectPlace', place);
         removeHoverMarkers();
         // dimiss menu when a place is selected
@@ -379,7 +391,7 @@ export default defineComponent({
       },
       hoverPlace(place?: Place) {
         if (!supportsHover()) {
-          // FIX: selecting automcomplete item on mobile requires double
+          // FIX: selecting autocomplete item on mobile requires double
           // tapping.
           //
           // On touch devices, where hover is not supported, this method is

--- a/services/frontend/www-app/src/components/SearchBox.vue
+++ b/services/frontend/www-app/src/components/SearchBox.vue
@@ -3,6 +3,7 @@
     <div class="input-field">
       <input
         ref="autoCompleteInput"
+        :tabindex="tabindex ?? 0"
         :placeholder="$props.hint || $t('where_to_question')"
         :value="inputText"
         clearable
@@ -151,6 +152,7 @@ import { placeDisplayName } from 'src/i18n/utils';
 export default defineComponent({
   name: 'SearchBox',
   props: {
+    tabindex: Number,
     initialInputText: String,
     initialPlace: Place,
     hint: String,

--- a/services/frontend/www-app/src/components/SearchBox.vue
+++ b/services/frontend/www-app/src/components/SearchBox.vue
@@ -134,7 +134,7 @@ import { defineComponent, Ref, ref } from 'vue';
 import { throttle } from 'lodash';
 import { Marker } from 'maplibre-gl';
 import { map } from './BaseMap.vue';
-import { QMenu, Platform, QInput } from 'quasar';
+import { Platform } from 'quasar';
 import Place, { PlaceId } from 'src/models/Place';
 import PeliasClient from 'src/services/PeliasClient';
 import Markers from 'src/utils/Markers';
@@ -168,7 +168,7 @@ export default defineComponent({
     },
     onInput(): void {
       this.inputText = this.autoCompleteInput().value;
-      this.updateAutocomplete(this.autoCompleteMenu());
+      this.updateAutocomplete();
     },
     onBlur(): void {
       if (Platform.is.ios) {
@@ -192,8 +192,8 @@ export default defineComponent({
         window.scroll(0, -1);
       }
     },
-    autoCompleteMenu(): QMenu {
-      return this.$refs.autoCompleteMenu as QMenu;
+    autoCompleteMenu(): HTMLElement {
+      return this.$refs.autoCompleteMenu as HTMLElement;
     },
     autoCompleteInput(): HTMLInputElement {
       return this.$refs.autoCompleteInput as HTMLInputElement;
@@ -320,8 +320,7 @@ export default defineComponent({
       placeHovered,
       mostRecentSearchIdx,
       removeHoverMarkers,
-      updateAutocomplete(menu: QMenu) {
-        console.log('updateAutocomplete. menu:', menu);
+      updateAutocomplete() {
         if (placeHovered.value) {
           placeHovered.value = undefined;
         }

--- a/services/frontend/www-app/src/components/SearchBox.vue
+++ b/services/frontend/www-app/src/components/SearchBox.vue
@@ -27,7 +27,6 @@
       ref="autoCompleteMenu"
       class="auto-complete-menu"
       v-on:before-hide="removeHoverMarkers"
-      :hidden="placeChoices.length == 0"
     >
       <q-list>
         <q-item

--- a/services/frontend/www-app/src/components/SearchBox.vue
+++ b/services/frontend/www-app/src/components/SearchBox.vue
@@ -6,7 +6,6 @@
       v-model="inputText"
       clearable
       :readonly="readonly"
-      :outlined="true"
       :debounce="0"
       :dense="true"
       v-on:clear="selectPlace(undefined)"
@@ -29,13 +28,23 @@
     >
     </q-input>
     <q-menu
+      square
       fit
       auto-close
       ref="autoCompleteMenu"
       :no-focus="true"
       :no-refocus="true"
       v-on:before-hide="removeHoverMarkers"
-      :target="($refs.autoCompleteInput as Element)"
+      @show="menuShowing = true"
+      @hide="menuShowing = false"
+      :target="(($refs.autoCompleteInput as Element)?.parentNode as Element)"
+      :style="{
+        border: 'solid black 2px',
+        'border-top': 'none',
+        'border-radius': '0 0 4px 4px',
+        opacity: (placeChoices?.length ?? 0) == 0 ? 0 : 1,
+      }"
+      :offset="[0, 0]"
     >
       <q-list>
         <q-item
@@ -60,8 +69,14 @@
 
 <style lang="scss">
 .search-box {
-  background: white;
-  border-radius: 4px;
+  border-radius: 4px 4px 0 0;
+  border: solid black 2px;
+  border-bottom: none;
+  padding: 4px;
+  background-color: white;
+  .q-field--highlighted .q-field__control:before {
+    // border: solid blue 4px;
+  }
 }
 </style>
 
@@ -87,9 +102,10 @@ export default defineComponent({
   },
   data(): {
     isAndroid: boolean;
+    menuShowing: boolean;
   } {
     const isAndroid = /(android)/i.test(navigator.userAgent);
-    return { isAndroid };
+    return { isAndroid, menuShowing: false };
   },
   methods: {
     onKeyDown(event: KeyboardEvent): void {

--- a/services/frontend/www-app/src/components/SearchBox.vue
+++ b/services/frontend/www-app/src/components/SearchBox.vue
@@ -329,6 +329,11 @@ export default defineComponent({
       selectPlace(place?: Place) {
         ctx.emit('didSelectPlace', place);
         removeHoverMarkers();
+        // dimiss menu when a place is selected
+        if (place) {
+          let el = (document.activeElement as HTMLElement);
+          el.blur();
+        }
       },
       hoverPlace(place?: Place) {
         if (!supportsHover()) {

--- a/services/frontend/www-app/src/components/SearchBox.vue
+++ b/services/frontend/www-app/src/components/SearchBox.vue
@@ -29,6 +29,7 @@
     >
     </q-input>
     <q-menu
+      fit
       auto-close
       ref="autoCompleteMenu"
       :no-focus="true"

--- a/services/frontend/www-app/src/components/SearchBox.vue
+++ b/services/frontend/www-app/src/components/SearchBox.vue
@@ -55,26 +55,50 @@
 
 <style lang="scss">
 .search-box {
+  position: relative;
+
+  background-color: white;
   border: solid #aaa 1px;
   border-radius: 4px;
-  background-color: white;
 
   .auto-complete-menu {
-    display: none;
+    // display: none;
+    position: absolute;
+    width: calc(100% + 3px);
+    left: -1.5px;
 
-    .q-item:first-child {
-      border-top: solid #aaa 1px;
-    }
+    background-color: white;
+    border: solid #aaa 1px;
+    border-top: none;
+    border-radius: 0 0 4px 4px;
+
+    // box-shadow: offset-x | offset-y | blur-radius | spread-radius | color
+    box-shadow: 0 0 2px 1px #aaa;
+    // clip-path: inset(Tpx Rpx Bpx Lpx);
+    clip-path: inset(0 -4px -4px -4px);
+
     .q-item {
       padding-left: 8px;
       padding-right: 8px;
     }
+
+    z-index: 1;
+
+    .q-item:first-child {
+      border-top: solid #aaa 1px;
+    }
   }
 
+  box-shadow: 0 0 3px 1px #aaa;
   &:focus-within {
-    box-shadow: 0 0 2px 1px #666;
+    box-shadow: 0 0 3px 1px #aaa;
 
-    .auto-complete-menu {
+    &:has(.auto-complete-menu .q-item:first-child) {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+
+    .auto-complete-menu:has(.q-item) {
       display: block;
     }
   }

--- a/services/frontend/www-app/src/components/TripSearch.vue
+++ b/services/frontend/www-app/src/components/TripSearch.vue
@@ -8,7 +8,7 @@
         v-on:did-select-place="didSelectFromPlace"
       />
       <q-btn
-        size="small"
+        size="12px"
         :style="{ marginLeft: '0.5em', marginRight: 0 }"
         flat
         round
@@ -25,7 +25,7 @@
         v-on:did-select-place="didSelectToPlace"
       />
       <q-btn
-        size="small"
+        size="12px"
         :style="{ marginLeft: '0.5em', marginRight: 0 }"
         flat
         round

--- a/services/frontend/www-app/src/components/TripSearch.vue
+++ b/services/frontend/www-app/src/components/TripSearch.vue
@@ -5,6 +5,7 @@
         :hint="$t('search.from')"
         :style="{ flex: 1 }"
         :initial-place="fromPlace"
+        :tabindex="1"
         v-on:did-select-place="didSelectFromPlace"
       />
       <q-btn
@@ -22,6 +23,7 @@
         :hint="$t('search.to')"
         :style="{ flex: 1 }"
         :initial-place="toPlace"
+        :tabindex="2"
         v-on:did-select-place="didSelectToPlace"
       />
       <q-btn

--- a/services/frontend/www-app/src/layouts/MainLayout.vue
+++ b/services/frontend/www-app/src/layouts/MainLayout.vue
@@ -60,6 +60,8 @@
 }
 
 #map {
+  z-index: 0;
+
   @media screen and (max-width: 800px) {
     // This is tall enough to keep the map UI from overlapping.
     // Ironically the "wide"/"desktop" layout is slightly less tall than the

--- a/services/frontend/www-app/src/layouts/MainLayout.vue
+++ b/services/frontend/www-app/src/layouts/MainLayout.vue
@@ -32,8 +32,10 @@
     order: 1;
 
     box-shadow: 0px 0px 5px #00000088;
-    // need z-index to cast shadow onto map
-    z-index: 1;
+    // needs z-index for:
+    //   - casting shadow onto map
+    //   - search results autocomplete menu rendered above .bottom-card
+    z-index: 2;
   }
   @media screen and (min-width: 800px) {
     order: 1;

--- a/services/frontend/www-app/src/pages/BaseMapPage.vue
+++ b/services/frontend/www-app/src/pages/BaseMapPage.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="top-card">
     <search-box
+      :tabindex="1"
       v-on:did-select-place="searchBoxDidSelectPlace"
       v-on:did-submit-search="
         (searchText) =>


### PR DESCRIPTION
This is a followup to https://github.com/headwaymaps/headway/pull/243, in which I initially tried (and failed) to overhaul the search widget. The details of the previous failure are in the reverted commit:
 https://github.com/headwaymaps/headway/commit/7f0f396da39ee775b78bc8b436f75ce7c88b0a3e

The improvements here are:

- UX: You can choose items from the autocomplete with your  keyboard arrows and Enter
- Design polish: The width of autocomplete menu matches search field
- Design polish: Removes the rounded corners between the input and menu, forming a nice continuous widget.
- UX: better tab indexing


## video

https://user-images.githubusercontent.com/217057/225184207-46a865bb-650a-4807-9e27-d677b1a61353.mp4

## after this change

<img width="960" alt="Screenshot 2023-03-14 at 6 56 16 PM" src="https://user-images.githubusercontent.com/217057/225184698-8853a55d-1e62-4d11-96da-8eeeaf562a42.png">

<img width="561" alt="Screenshot 2023-03-14 at 6 54 03 PM" src="https://user-images.githubusercontent.com/217057/225184382-01e3587a-417b-4683-8fca-bd7c11f4c933.png">

## before this change

- note the rounded corners between the menu and input
- note the mismatched widths between menu and input

<img width="962" alt="Screenshot 2023-03-14 at 6 55 41 PM" src="https://user-images.githubusercontent.com/217057/225184796-7fa482da-9848-4596-bfa2-b5a139084a52.png">

<img width="561" alt="Screenshot 2023-03-14 at 6 55 17 PM" src="https://user-images.githubusercontent.com/217057/225184791-cf62702a-77e5-498f-8d38-14c65d8c81db.png">


## notes

I originally tried to implement this using QInput and QMenu, but I was fighting the framework so much that I gave up and built things more "from scratch".

There's still more to do - in particular:
- add a progress indicator.
- zoom to the highlighted item?
- the results are overly verbose - e.g. "Seattle, King County, Washing State, United States of America" should probably be something like "Seattle, WA" or "Seattle USA" or at the very least, get rid of the county. It's hard to get too concise without making assumptions about who is searching - foreign cities need more context, but we currently don't make any guesses about which ones are foreign.

Getting a shared border around the input field and the autocomplete menu was tricky.

- If we want to size the autocomplete menu to be the same width as the input text, the easiest thing is if they share a parent element. Yes there are javascript solutions, but this "just add a listener" approach is what I was fighting against the framework with. In my experience, everything is easiest if you can express it declaratively. So, a shared parent element it is!
- However, the autocomplete menu needs to be positioned absolutely, else it'll push all the rest of the page content down.
- Positioning absolutely and adding a border (except where the input and menu meet) *almost* worked. It looked good on chrome, but safari rendered the input slightly wider than the menu.
- So I thought to use `outline` instead of border which is like a border, but doesn't affect the sizing of the box. Unfortunately you cannot have rounded corners with an outline.
- So I went with a box shadow, which isn't ideal, but does delineate the field OK and you can round the shadow with the corners.
- However: you can't have a box shadow on just certain sides, so I used this css clip thing I've never heard of, but which apparently has been around [since at least 2020](https://caniuse.com/css-clip-path).

This pretty much works, but the downsides are:
- there's a little detectable smudge in the shadow between the edge of the input and the edge of the menu, but it's pretty minor
- really - i don't want a shadow. I just want a border. 🤷 



(The commits are kind of a mess, so I intend to do a squash merge)