### PR TITLE
[www] FIX: autocomplete menu shows stale results after swap locations

### DIFF
--- a/services/frontend/www-app/src/components/SearchBox.vue
+++ b/services/frontend/www-app/src/components/SearchBox.vue
@@ -258,7 +258,11 @@ export default defineComponent({
   },
   watch: {
     initialPlace: {
-      handler(newValue?: Place) {
+      handler(newValue?: Place, oldValue?: Place) {
+        if (newValue != oldValue) {
+          this.placeChoices = [];
+        }
+
         this.inputText = newValue ? placeDisplayName(newValue) : undefined;
       },
     },


### PR DESCRIPTION
Note that this was an issue even before the big search bar refactor in 2ca6fbb
