### PR TITLE
transit: datestamp graphs and build them from the same basemap data

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -77,12 +77,20 @@ save-otp:
     ARG --required area
     ARG --required transit_feeds
 
+    # See usage in otp-build
+    ARG clip_to_area
+
     COPY +cache-buster/todays_date .
     ARG cache_key=$(cat todays_date)
 
-    COPY (+otp-build/graph.obj --area=${area} --transit_feeds=${transit_feeds} --cache_key=${cache_key}) /graph.obj
+    COPY (+otp-build/graph.obj --area=${area} --clip_to_area=${clip_to_area} --transit_feeds=${transit_feeds} --cache_key=${cache_key}) /graph.obj
+
     RUN zstd /graph.obj
-    SAVE ARTIFACT /graph.obj.zst AS LOCAL ./data/${area}-${cache_key}.graph.obj.zst
+    ARG output_name=$clip_to_area
+    IF [ -n "$output_name" ]
+        ARG output_name="$area"
+    END
+    SAVE ARTIFACT /graph.obj.zst AS LOCAL ./data/${output_name}-${cache_key}.graph.obj.zst
 
 save-mbtiles:
     FROM +save-base
@@ -143,10 +151,39 @@ images:
 extract:
     FROM +downloader-base
     ARG --required area
-    COPY --if-exists ${area}.osm.pbf /data/data.osm.pbf
-    IF [ ! -f "/data/data.osm.pbf" ]
-        RUN wget -nv -U headway/1.0 -O /data/data.osm.pbf "https://download.bbbike.org/osm/bbbike/${area}/${area}.osm.pbf"
+    ARG clip_bbox
+
+    RUN apt-get update \
+        && apt-get install -y --no-install-recommends osmium-tool \
+        && rm -rf /var/lib/apt/lists/*
+
+    WORKDIR /data
+
+    COPY --if-exists ${area}.osm.pbf data.osm.pbf
+    IF [ ! -f data.osm.pbf ]
+        RUN wget -nv -U headway/1.0 -O data.osm.pbf "https://download.bbbike.org/osm/bbbike/${area}/${area}.osm.pbf"
     END
+
+    IF [ ! -f data.osm.pbf ]
+        RUN echo "osm file not found"
+        RUN exit 1
+    END
+
+    IF [ -n "${clip_bbox}" ]
+        # I don't understand why the following line doesn't work:
+        #    ARG comma_separated_bbox=$(echo ${clip_bbox} | sed 's/ /,/g')
+        # ... but anway, here's a 2-line work around:
+        RUN echo ${clip_bbox} | sed 's/ /,/g' > comma_separated_bbox.txt
+        ARG comma_separated_bbox=$(cat comma_separated_bbox.txt)
+
+        # It'd be nice to mv rather than cp, but I get this weird error:
+        # >    mv: cannot move 'data.osm.pbf' to a subdirectory of itself, 'unclipped.osm.pbf'
+        # I'm not sure if this is a bug with large files+docker+zfs or what.
+        # RUN mv data.osm.pbf unclipped.osm.pbf && \
+        RUN cp data.osm.pbf unclipped.osm.pbf && rm data.osm.pbf && \
+            osmium extract --bbox="$comma_separated_bbox" unclipped.osm.pbf --output=data.osm.pbf
+    END
+
     SAVE ARTIFACT /data/data.osm.pbf /data.osm.pbf
 
 ##############################
@@ -364,20 +401,22 @@ gtfs-enumerate:
     COPY (+gtfs-get-mobilitydb/mobilitydb.csv --cache_key=${cache_key}) mobilitydb.csv
 
     ARG --required area
-    ARG bbox
-    ENV BBOX=${bbox}
-    IF [ ! -z "${BBOX}" ]
-        ENV HEADWAY_BBOX=${BBOX}
-    ELSE
-        COPY services/gtfs/bboxes.csv /gtfs/bboxes.csv
-        ARG guessed_bbox=$(grep "${area}:" /gtfs/bboxes.csv | cut -d':' -f2)
-        ENV HEADWAY_BBOX=${guessed_bbox}
-    END
-
+    COPY (+bbox/bbox.txt --area=${area}) bbox.txt
+    ARG bbox=$(cat bbox.txt)
+    ENV HEADWAY_BBOX=${bbox}
     COPY ./services/gtfs/enumerate_gtfs_feeds.py /gtfs/
     RUN python /gtfs/enumerate_gtfs_feeds.py mobilitydb.csv
 
     SAVE ARTIFACT /gtfs_feeds/gtfs_feeds.csv /gtfs_feeds.csv AS LOCAL ./data/${area}-${cache_key}.gtfs_feeds.csv
+
+bbox:
+    FROM debian:bullseye-slim
+    ARG --required area
+    COPY services/gtfs/bboxes.csv /gtfs/bboxes.csv
+    # ensure `area` has an entry in bboxes.csv, otherwise you'll need to add one
+    RUN test $(grep "${area}:" /gtfs/bboxes.csv | wc -l) -eq 1
+    RUN grep "${area}:" /gtfs/bboxes.csv | cut -d':' -f2 | tee bbox.txt 
+    SAVE ARTIFACT bbox.txt /bbox.txt
 
 gtfs-get-mobilitydb:
     FROM +gtfs-base
@@ -421,15 +460,32 @@ otp-build:
     ARG --required area
     ARG --required cache_key
 
-    COPY (+gtfs-build/gtfs.tar.zst --transit_feeds=${transit_feeds} --cache_key=${cache_key}) /var/opentripplanner
-    COPY (+extract/data.osm.pbf --area=${area}) /var/opentripplanner
-
     WORKDIR /var/opentripplanner
 
     RUN apt-get update \
         && apt-get install -y --no-install-recommends zstd \
         && rm -rf /var/lib/apt/lists/*
 
+    ARG clip_to_area
+    IF [ -n "$clip_to_area" ]
+        # Clip the mapping data to the area's bbox to save memory.
+        #
+        # This option is only relevant if you are configuring small transit
+        # zones within an otherwise huge map. OTP reads all the map data into
+        # memory, which can be very large.
+        #
+        # In the case of feeds which are only partially within our bbox,
+        # curently we'd clip the mapping data for any parts of the feed that
+        # fall outside of the bbox - if the proves problematic, we may want to
+        # compute the bbox from gtfs/shapes.txt
+        COPY (+bbox/bbox.txt --area=${clip_to_area}) bbox.txt
+        ARG clip_bbox=$(cat bbox.txt)
+        COPY (+extract/data.osm.pbf --area=${area} --clip_bbox=${clip_bbox}) /var/opentripplanner
+    ELSE
+        COPY (+extract/data.osm.pbf --area=${area}) /var/opentripplanner
+    END
+
+    COPY (+gtfs-build/gtfs.tar.zst --transit_feeds=${transit_feeds} --cache_key=${cache_key}) /var/opentripplanner
     RUN tar --zstd -xf gtfs.tar.zst
 
     RUN --entrypoint -- --build --save

--- a/bin/build-los-angeles
+++ b/bin/build-los-angeles
@@ -17,7 +17,7 @@ EARTHLY_ARGS=${@:1}
 
 if [ -z "$HEADWAY_CONTAINER_TAG" ]
 then
-    # The seattle deployment is for testing, and thus always uses dev containers
+    # The los angeles deployment is for testing, and thus always uses dev containers
     HEADWAY_CONTAINER_TAG=dev
 fi
 

--- a/bin/build-planet
+++ b/bin/build-planet
@@ -23,15 +23,7 @@ fi
 # This job assumes you've already downloaded the planet file into the repository root
 source "${SCRIPT_DIR}/../k8s/planet.env"
 
-# with_log earthly $EARTHLY_ARGS -P +build --area=$HEADWAY_AREA --countries=ALL --tag=$HEADWAY_CONTAINER_TAG
+with_log earthly $EARTHLY_ARGS -P +build --area=$HEADWAY_AREA --countries=ALL --tag=$HEADWAY_CONTAINER_TAG
 
-TRANSIT_FEEDS=data/Seattle-2023-01-04.gtfs_feeds.csv
-TRANSIT_AREA=Seattle
-with_log earthly ${EARTHLY_ARGS} -P +save-gtfs --area=${TRANSIT_AREA} --tag=${HEADWAY_CONTAINER_TAG} --transit_feeds=${TRANSIT_FEEDS}
-with_log earthly ${EARTHLY_ARGS} -P +save-otp --area=${TRANSIT_AREA} --tag=${HEADWAY_CONTAINER_TAG} --transit_feeds=${TRANSIT_FEEDS}
-
-TRANSIT_FEEDS=data/LosAngeles-2023-01-21.gtfs_feeds.csv
-TRANSIT_AREA=LosAngeles
-with_log earthly ${EARTHLY_ARGS} -P +save-gtfs --area=${TRANSIT_AREA} --tag=${HEADWAY_CONTAINER_TAG} --transit_feeds=${TRANSIT_FEEDS}
-with_log earthly ${EARTHLY_ARGS} -P +save-otp --area=${TRANSIT_AREA} --tag=${HEADWAY_CONTAINER_TAG} --transit_feeds=${TRANSIT_FEEDS}
+bin/build-transit
 

--- a/bin/build-transit
+++ b/bin/build-transit
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -xe
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+bin_name=$(basename $0)
+log_filename="${bin_name}-$(date +%Y-%m-%d-%H:%M:%S).log"
+log_dir=/pool1/logs
+log_file="${log_dir}/${log_filename}"
+
+function with_log {
+  $@ > >(tee -a "${log_file}.out") 2> >(tee -a "${log_file}.err" >&2)
+}
+
+EARTHLY_ARGS=${@:1}
+
+if [ -z "$HEADWAY_CONTAINER_TAG" ]
+then
+source "${SCRIPT_DIR}/_headway_version.sh"
+fi
+
+# This job assumes you've already downloaded the planet file into the repository root
+source "${SCRIPT_DIR}/../k8s/planet.env"
+
+TRANSIT_FEEDS=data/Seattle-2023-01-04.gtfs_feeds.csv
+TRANSIT_AREA=Seattle
+with_log earthly ${EARTHLY_ARGS} -P +save-gtfs --area=${TRANSIT_AREA} --tag=${HEADWAY_CONTAINER_TAG} --transit_feeds=${TRANSIT_FEEDS}
+with_log earthly ${EARTHLY_ARGS} -P +save-otp --area=${TRANSIT_AREA} --tag=${HEADWAY_CONTAINER_TAG} --transit_feeds=${TRANSIT_FEEDS}
+
+TRANSIT_FEEDS=data/LosAngeles-2023-01-21.gtfs_feeds.csv
+TRANSIT_AREA=LosAngeles
+with_log earthly ${EARTHLY_ARGS} -P +save-gtfs --area=${TRANSIT_AREA} --tag=${HEADWAY_CONTAINER_TAG} --transit_feeds=${TRANSIT_FEEDS}
+with_log earthly ${EARTHLY_ARGS} -P +save-otp --area=${TRANSIT_AREA} --tag=${HEADWAY_CONTAINER_TAG} --transit_feeds=${TRANSIT_FEEDS}
+

--- a/bin/build-transit
+++ b/bin/build-transit
@@ -15,21 +15,12 @@ function with_log {
 
 EARTHLY_ARGS=${@:1}
 
-if [ -z "$HEADWAY_CONTAINER_TAG" ]
-then
-source "${SCRIPT_DIR}/_headway_version.sh"
-fi
-
-# This job assumes you've already downloaded the planet file into the repository root
-source "${SCRIPT_DIR}/../k8s/planet.env"
-
 TRANSIT_FEEDS=data/Seattle-2023-01-04.gtfs_feeds.csv
 TRANSIT_AREA=Seattle
-with_log earthly ${EARTHLY_ARGS} -P +save-gtfs --area=${TRANSIT_AREA} --tag=${HEADWAY_CONTAINER_TAG} --transit_feeds=${TRANSIT_FEEDS}
-with_log earthly ${EARTHLY_ARGS} -P +save-otp --area=${TRANSIT_AREA} --tag=${HEADWAY_CONTAINER_TAG} --transit_feeds=${TRANSIT_FEEDS}
+with_log earthly ${EARTHLY_ARGS} -P +save-gtfs --area=${TRANSIT_AREA} --transit_feeds=${TRANSIT_FEEDS}
+with_log earthly ${EARTHLY_ARGS} -P +save-otp --area=${TRANSIT_AREA} --transit_feeds=${TRANSIT_FEEDS}
 
 TRANSIT_FEEDS=data/LosAngeles-2023-01-21.gtfs_feeds.csv
 TRANSIT_AREA=LosAngeles
-with_log earthly ${EARTHLY_ARGS} -P +save-gtfs --area=${TRANSIT_AREA} --tag=${HEADWAY_CONTAINER_TAG} --transit_feeds=${TRANSIT_FEEDS}
-with_log earthly ${EARTHLY_ARGS} -P +save-otp --area=${TRANSIT_AREA} --tag=${HEADWAY_CONTAINER_TAG} --transit_feeds=${TRANSIT_FEEDS}
-
+with_log earthly ${EARTHLY_ARGS} -P +save-gtfs --area=${TRANSIT_AREA} --transit_feeds=${TRANSIT_FEEDS}
+with_log earthly ${EARTHLY_ARGS} -P +save-otp --area=${TRANSIT_AREA} --transit_feeds=${TRANSIT_FEEDS}

--- a/bin/build-transit
+++ b/bin/build-transit
@@ -15,12 +15,16 @@ function with_log {
 
 EARTHLY_ARGS=${@:1}
 
+# This job assumes you've already downloaded the planet file into the repository root
+source "${SCRIPT_DIR}/../k8s/planet.env"
+PLANET_AREA="$HEADWAY_AREA"
+
 TRANSIT_FEEDS=data/Seattle-2023-01-04.gtfs_feeds.csv
 TRANSIT_AREA=Seattle
 with_log earthly ${EARTHLY_ARGS} -P +save-gtfs --area=${TRANSIT_AREA} --transit_feeds=${TRANSIT_FEEDS}
-with_log earthly ${EARTHLY_ARGS} -P +save-otp --area=${TRANSIT_AREA} --transit_feeds=${TRANSIT_FEEDS}
+with_log earthly ${EARTHLY_ARGS} -P +save-otp --area=${PLANET_AREA} --clip_to_area=${TRANSIT_AREA} --transit_feeds=${TRANSIT_FEEDS}
 
 TRANSIT_FEEDS=data/LosAngeles-2023-01-21.gtfs_feeds.csv
 TRANSIT_AREA=LosAngeles
 with_log earthly ${EARTHLY_ARGS} -P +save-gtfs --area=${TRANSIT_AREA} --transit_feeds=${TRANSIT_FEEDS}
-with_log earthly ${EARTHLY_ARGS} -P +save-otp --area=${TRANSIT_AREA} --transit_feeds=${TRANSIT_FEEDS}
+with_log earthly ${EARTHLY_ARGS} -P +save-otp --area=${PLANET_AREA} --clip_to_area=${TRANSIT_AREA} --transit_feeds=${TRANSIT_FEEDS}

--- a/bin/publish-data
+++ b/bin/publish-data
@@ -32,25 +32,26 @@ function kill_uploads() {
 trap kill_uploads EXIT
 
 function upload() {
-  INPUT=$1
+  INPUT_GLOB=$1
   OUTPUT_PREFIX=$2
 
-  RESOURCE="${OUTPUT_PREFIX}/$(basename $INPUT)"
-  BUCKET=$HEADWAY_S3_BUCKET
-
-  INPUT_PATH="${DATA_ROOT}/${INPUT}"
-  if [ ! -f "$INPUT_PATH" ]; then
-    echo "target file doesn't exist: '${INPUT_PATH}'"
-    exit 1;
+  INPUT_PATH_GLOB="${DATA_ROOT}/${INPUT_GLOB}"
+  if ! ls $INPUT_PATH_GLOB 1> /dev/null 2>&1; then
+    echo "target file doesn't exist: '${INPUT_PATH_GLOB}'"
+    exit 1
   fi
 
-  # I'm seeing much faster uploads with the openstack swift client vs the aws cli
-  # Plus, my host seems to be pretty flaky with large uploads via the `aws s3` cli.
-  #
-  # Note you'll need to be authenticated to run this.
-  #   e.g. (source ~/openrc.sh && bin/publish-data)
-  echo "Uploading ${INPUT_PATH} -> s3://${BUCKET}/${RESOURCE}"
-  swift upload --segment-size=5G --skip-identical "$BUCKET" "$INPUT_PATH" --object-name="$RESOURCE" & upload_pids+=($!)
+  for INPUT_PATH in $INPUT_PATH_GLOB; do
+    RESOURCE="${OUTPUT_PREFIX}/$(basename "$INPUT_PATH")"
+    BUCKET=$HEADWAY_S3_BUCKET
+    # I'm seeing much faster uploads with the openstack swift client vs the aws cli
+    # Plus, my host seems to be pretty flaky with large uploads via the `aws s3` cli.
+    #
+    # Note you'll need to be authenticated to run this.
+    #   e.g. (source ~/openrc.sh && bin/publish-data)
+    echo "Uploading ${INPUT_PATH} -> s3://${BUCKET}/${RESOURCE}"
+    swift upload --segment-size=5G --skip-identical "$BUCKET" "$INPUT_PATH" --object-name="$RESOURCE" & upload_pids+=($!)
+  done
 }
 
 source "${REPO_ROOT}/.env"
@@ -80,14 +81,13 @@ upload "${HEADWAY_AREA}.placeholder.tar.zst"   "${HEADWAY_DATA_TAG}/${HEADWAY_AR
 upload "${HEADWAY_AREA}.osm.pbf"               "${HEADWAY_DATA_TAG}/${HEADWAY_AREA_TAG}"
 
 for TRANSIT_AREA in $HEADWAY_TRANSIT_AREAS; do
-
-  upload "${TRANSIT_AREA}.graph.obj.zst" "${HEADWAY_DATA_TAG}/${HEADWAY_AREA_TAG}"
-  upload "${TRANSIT_AREA}.gtfs.tar.zst"  "${HEADWAY_DATA_TAG}/${HEADWAY_AREA_TAG}"
-
+  upload "${TRANSIT_AREA}*.gtfs_feeds.csv" "${HEADWAY_DATA_TAG}/${HEADWAY_AREA_TAG}"
+  upload "${TRANSIT_AREA}*.graph.obj.zst" "${HEADWAY_DATA_TAG}/${HEADWAY_AREA_TAG}"
+  upload "${TRANSIT_AREA}*.gtfs.tar.zst"  "${HEADWAY_DATA_TAG}/${HEADWAY_AREA_TAG}"
 done
 
 # These files are generic across all areas
-upload natural_earth.mbtiles          "${HEADWAY_DATA_TAG}"
+upload natural_earth.mbtiles "${HEADWAY_DATA_TAG}"
 
 rets=()
 for pid in ${upload_pids[*]}; do

--- a/bin/publish-data
+++ b/bin/publish-data
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 function usage() {
-cat << EOF
+  cat << EOF
 usage: $0 <site.env>
 examples:
     $0 k8s/planet.env
@@ -13,8 +13,8 @@ EOF
 }
 
 if [ ! $# -eq 1 ]; then
-    usage
-    exit 1
+  usage
+  exit 1
 fi
 
 
@@ -23,10 +23,10 @@ DATA_ROOT="${REPO_ROOT}/data"
 
 upload_pids=()
 function kill_uploads() {
-    echo "Killing any in-progress uploads before exiting"
-    for pid in ${upload_pids[*]}; do
-        kill "${pid[*]}"
-    done
+  echo "Killing any in-progress uploads before exiting"
+  for pid in ${upload_pids[*]}; do
+    kill "${pid[*]}"
+  done
 }
 
 trap kill_uploads EXIT
@@ -40,8 +40,8 @@ function upload() {
 
   INPUT_PATH="${DATA_ROOT}/${INPUT}"
   if [ ! -f "$INPUT_PATH" ]; then
-      echo "target file doesn't exist: '${INPUT_PATH}'"
-      exit 1;
+    echo "target file doesn't exist: '${INPUT_PATH}'"
+    exit 1;
   fi
 
   # I'm seeing much faster uploads with the openstack swift client vs the aws cli
@@ -61,8 +61,8 @@ local_data_tag=$HEADWAY_DATA_TAG
 source "${REPO_ROOT}/bin/_headway_version.sh"
 
 if [ ! -z "$HEADWAY_TAG" ]; then
-    HEADWAY_CONTAINER_TAG="$HEADWAY_TAG"
-    HEADWAY_DATA_TAG="$HEADWAY_TAG"
+  HEADWAY_CONTAINER_TAG="$HEADWAY_TAG"
+  HEADWAY_DATA_TAG="$HEADWAY_TAG"
 fi
 
 export HEADWAY_CONTAINER_TAG="${local_container_tag:-$HEADWAY_CONTAINER_TAG}"
@@ -81,8 +81,8 @@ upload "${HEADWAY_AREA}.osm.pbf"               "${HEADWAY_DATA_TAG}/${HEADWAY_AR
 
 for TRANSIT_AREA in $HEADWAY_TRANSIT_AREAS; do
 
-upload "${TRANSIT_AREA}.graph.obj.zst" "${HEADWAY_DATA_TAG}/${HEADWAY_AREA_TAG}"
-upload "${TRANSIT_AREA}.gtfs.tar.zst"  "${HEADWAY_DATA_TAG}/${HEADWAY_AREA_TAG}"
+  upload "${TRANSIT_AREA}.graph.obj.zst" "${HEADWAY_DATA_TAG}/${HEADWAY_AREA_TAG}"
+  upload "${TRANSIT_AREA}.gtfs.tar.zst"  "${HEADWAY_DATA_TAG}/${HEADWAY_AREA_TAG}"
 
 done
 

--- a/k8s/configs/planet-dev/deployment-config.yaml
+++ b/k8s/configs/planet-dev/deployment-config.yaml
@@ -3,17 +3,17 @@ kind: ConfigMap
 metadata:
   name: deployment-config
 data:
-  area: maps-earth-planet-v1.22
+  area: maps-earth-planet-v1.24
   public-url: https://maps.earth
   bbox: ""
   enable-transit-routing: "1"
   natural-earth-source-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/natural_earth.mbtiles
-  mbtiles-source-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.22/maps-earth-planet-v1.22.mbtiles
-  valhalla-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.22/maps-earth-planet-v1.22.valhalla.tar.zst
-  placeholder-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.22/maps-earth-planet-v1.22.placeholder.tar.zst
-  elasticsearch-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.22/maps-earth-planet-v1.22.elasticsearch.tar.zst
-  otp-graph-urls.seattle: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.22/Seattle.graph.obj.zst
-  otp-graph-urls.losangeles: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.22/LosAngeles.graph.obj.zst
+  mbtiles-source-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.24/maps-earth-planet-v1.24.mbtiles
+  valhalla-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.24/maps-earth-planet-v1.24.valhalla.tar.zst
+  placeholder-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.24/maps-earth-planet-v1.24.placeholder.tar.zst
+  elasticsearch-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.24/maps-earth-planet-v1.24.elasticsearch.tar.zst
+  otp-graph-urls.seattle: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.24/Seattle.graph.obj.zst
+  otp-graph-urls.losangeles: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.24/LosAngeles.graph.obj.zst
   pelias-config-json: |
     {
       "logger": {

--- a/k8s/configs/planet/deployment-config.yaml
+++ b/k8s/configs/planet/deployment-config.yaml
@@ -3,17 +3,17 @@ kind: ConfigMap
 metadata:
   name: deployment-config
 data:
-  area: maps-earth-planet-v1.22
+  area: maps-earth-planet-v1.24
   public-url: https://maps.earth
   bbox: ""
   enable-transit-routing: "1"
   natural-earth-source-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/natural_earth.mbtiles
-  mbtiles-source-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.22/maps-earth-planet-v1.22.mbtiles
-  valhalla-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.22/maps-earth-planet-v1.22.valhalla.tar.zst
-  placeholder-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.22/maps-earth-planet-v1.22.placeholder.tar.zst
-  elasticsearch-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.22/maps-earth-planet-v1.22.elasticsearch.tar.zst
-  otp-graph-urls.seattle: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.22/Seattle.graph.obj.zst
-  otp-graph-urls.losangeles: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.22/LosAngeles.graph.obj.zst
+  mbtiles-source-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.24/maps-earth-planet-v1.24.mbtiles
+  valhalla-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.24/maps-earth-planet-v1.24.valhalla.tar.zst
+  placeholder-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.24/maps-earth-planet-v1.24.placeholder.tar.zst
+  elasticsearch-artifact-url: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.24/maps-earth-planet-v1.24.elasticsearch.tar.zst
+  otp-graph-urls.seattle: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.24/Seattle.graph.obj.zst
+  otp-graph-urls.losangeles: https://storage.us-west-or.cloud.ovh.us/v1/AUTH_7f440916c359460f8ca71f785ffe3f28/maps.earth/0.3.0/maps-earth-planet-v1.24/LosAngeles.graph.obj.zst
   pelias-config-json: |
     {
       "logger": {

--- a/k8s/planet.env
+++ b/k8s/planet.env
@@ -1,4 +1,4 @@
-export HEADWAY_AREA=maps-earth-planet-v1.22
+export HEADWAY_AREA=maps-earth-planet-v1.24
 export HEADWAY_AREA_TAG="$HEADWAY_AREA"
 export HEADWAY_PUBLIC_URL=https://maps.earth
 export HEADWAY_SERVICE_PORT=30400


### PR DESCRIPTION
This PR consists of a few tiny changes and then two slightly larger ones:

## include a date stamp in the exported transit graph

Transit graphs are built from GTFS feeds, which have a specific finite calendar. Since they expire, it's helpful to label them with their creation date to get some kind of idea of which ones are more relevant.

## build transit from the same base map data

Headway requires an OSM extract to produce it's tiles, transit routing, non-transit routing, geocoding, etc.

There's two ways to get this extract: You can bring your own `<filename>.osm.pbf`, and specify `--area=<filename>` **or** you can specify an `--area=Cityname` with a  Cityname that corresponds to one of the bbbike.org extracts, which will be downloaded at build time.

If you were bringing your own data, and the area you were using to build your transit zone didn't match the area of your `<filename>.osm.pbf`, headway would download a new extract for each transit area from bbike.org, meaning that a *separate* osm.pbf would be consulted for transit calculations, potentially with different versions of features from the input used in valhalla, tilebuilder, pelias, etc. 

Now, we extract the transit zones directly from the "main" extract, eliminating the chance that problems arise due to the transit data sources being "out of sync" with the data source used elsewhere in the data pipeline.