### PR TITLE
[tileserver] render ferry route lines

### DIFF
--- a/services/tileserver/styles/basic/style.json
+++ b/services/tileserver/styles/basic/style.json
@@ -1297,6 +1297,27 @@
       }
     },
     {
+      "id": "route_ferry",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["in", "class", "ferry"]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#99d",
+        "line-width": 2,
+        "line-dasharray": [0.3, 2]
+      }
+    },
+    {
       "id": "water_name_line",
       "type": "symbol",
       "source": "openmaptiles",


### PR DESCRIPTION
Previously we were rendering the labels, but not the route lines.

**before**
<img width="746" alt="Screenshot 2023-03-20 at 3 59 04 PM" src="https://user-images.githubusercontent.com/217057/226484106-6b1b2a38-96d1-48df-950d-a0a4e0e3dfe2.png">


**after**
<img width="759" alt="Screenshot 2023-03-20 at 3 58 22 PM" src="https://user-images.githubusercontent.com/217057/226484117-1221e676-2536-4b55-9a55-f7f69438e063.png">

