### PR TITLE
[tileserver] water above sand, waterways above water

### DIFF
--- a/services/tileserver/styles/basic/style.json
+++ b/services/tileserver/styles/basic/style.json
@@ -146,6 +146,22 @@
       }
     },
     {
+      "id": "landcover_sand",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "filter": ["all", ["==", "class", "sand"]],
+      "paint": {"fill-color": "rgba(247, 239, 195, 1)"}
+    },
+    {
+      "id": "water",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "water",
+      "filter": ["all", ["!=", "brunnel", "tunnel"]],
+      "paint": {"fill-color": "rgb(158,189,255)"}
+    },
+    {
       "id": "waterway_river",
       "type": "line",
       "source": "openmaptiles",
@@ -168,22 +184,6 @@
         "line-color": "#a0c8f0",
         "line-width": {"base": 1.3, "stops": [[13, 0.5], [20, 6]]}
       }
-    },
-    {
-      "id": "water",
-      "type": "fill",
-      "source": "openmaptiles",
-      "source-layer": "water",
-      "filter": ["all", ["!=", "brunnel", "tunnel"]],
-      "paint": {"fill-color": "rgb(158,189,255)"}
-    },
-    {
-      "id": "landcover_sand",
-      "type": "fill",
-      "source": "openmaptiles",
-      "source-layer": "landcover",
-      "filter": ["all", ["==", "class", "sand"]],
-      "paint": {"fill-color": "rgba(247, 239, 195, 1)"}
     },
     {
       "id": "aeroway_fill",


### PR DESCRIPTION
See https://maps.earth/place/-124.2153059153271,47.24507569180591

The Moclips River dumps into the Pacific Ocean, but with the previous rendering it appears like there is a bunch of sand between where the river ends and the ocean begins.

Some related discussion:

https://help.openstreetmap.org/questions/49790/coastline-at-highwater-vs-lowwater

> It has been a long-held practice in OSM (2008 or earlier) to map
coastlines at the Mean High Water Spring as stated here:


The new layer ordering seems to be more consistent with how the map is expected to be rendered, though regional norms might vary.

**before**

<img width="580" alt="Screenshot 2023-03-22 at 4 46 56 PM" src="https://user-images.githubusercontent.com/217057/227064092-ef2534f5-7b24-4133-a2d3-e51d18717949.png">

**after**

<img width="463" alt="Screenshot 2023-03-22 at 4 50 08 PM" src="https://user-images.githubusercontent.com/217057/227064089-040d2488-56b1-4dd7-bf09-ea45dcf4e307.png">

In this area, it means we end up not showing any sand, because it's under the high tide line where the water is mapped. It might be nice if we could include some kind of tidal zone information, but I'm still thinking about how/if we can do that.

---

**also** make sure waterways are on top of the sand:

**before**

<img width="264" alt="Screenshot 2023-03-22 at 4 45 57 PM" src="https://user-images.githubusercontent.com/217057/227064098-9e18f070-be2b-4a8d-ba36-c0df53dda702.png">

**after**
<img width="152" alt="Screenshot 2023-03-22 at 4 45 46 PM" src="https://user-images.githubusercontent.com/217057/227064086-9df4188b-bc93-4f76-bb25-a0c13f6d1798.png">

