### PR TITLE
[www] Fix: ferry icon missing in transit directions

### DIFF
--- a/services/frontend/www-app/src/models/Itinerary.ts
+++ b/services/frontend/www-app/src/models/Itinerary.ts
@@ -171,7 +171,7 @@ export class ItineraryLeg {
     this.raw = otp;
   }
 
-  get emoji(): string | undefined {
+  get emoji(): string {
     switch (this.mode) {
       case OTPMode.Walk:
         return '🚶‍♀️';
@@ -179,6 +179,7 @@ export class ItineraryLeg {
       case OTPMode.Transit:
         return '🚍';
       case OTPMode.Train:
+      case OTPMode.Rail:
         return '🚆';
       case OTPMode.Subway:
         return '🚇';
@@ -191,9 +192,13 @@ export class ItineraryLeg {
         return '🚡';
       case OTPMode.Gondola:
         return '🚠';
+      case OTPMode.Car:
+        return '🚙';
+      case OTPMode.Ferry:
+        return '⛴️';
       default:
-        console.warn('no emoji for mode', this.mode);
-        return undefined;
+        console.error('no emoji for mode', this.mode);
+        return '';
     }
   }
 


### PR DESCRIPTION
Added the other missing icons as well.

**before**
note the weird _undefined_ text in the route summary

<img width="868" alt="Screenshot 2023-03-24 at 11 15 52 AM" src="https://user-images.githubusercontent.com/217057/227607379-1a93382c-0019-4ffb-993d-6c6ca1ff7a42.png">



**after**
<img width="868" alt="Screenshot 2023-03-24 at 11 15 11 AM" src="https://user-images.githubusercontent.com/217057/227607395-45a92435-184c-4aaf-a832-f4f1483cd9d9.png">


