### PR TITLE
[transitmux] accept URL encoded query params

### DIFF
--- a/services/transitmux/src/bin/transitmux-server/plan.rs
+++ b/services/transitmux/src/bin/transitmux-server/plan.rs
@@ -56,7 +56,7 @@ where
 {
     use serde::de::Error;
 
-    let s: &str = Deserialize::deserialize(deserializer)?;
+    let s: String = Deserialize::deserialize(deserializer)?;
     use std::str::FromStr;
     let mut iter = s.split(',').map(f64::from_str);
 


### PR DESCRIPTION
URL encoded query strings will fail to deserialize as borrowed strings.

This doesn't affect the current deployment, but I'm working on another feature that ran into this.

