### PR TITLE
Set "Depart at" for transit

### DIFF
--- a/services/frontend/www-app/src/i18n/en-US/index.ts
+++ b/services/frontend/www-app/src/i18n/en-US/index.ts
@@ -54,4 +54,6 @@ export default {
   },
   walk_distance: '{preformattedDistance} walk',
   route_picker_show_route_details_btn: 'Details',
+  trip_search_depart_at: 'Leave at',
+  trip_search_depart_now: 'Leave now',
 };

--- a/services/frontend/www-app/src/models/Itinerary.ts
+++ b/services/frontend/www-app/src/models/Itinerary.ts
@@ -96,9 +96,17 @@ export default class Itinerary implements Trip {
   public static async fetchBest(
     from: LngLat,
     to: LngLat,
-    distanceUnits: DistanceUnits
+    distanceUnits: DistanceUnits,
+    departureTime?: string,
+    departureDate?: string
   ): Promise<Result<Itinerary[], ItineraryError>> {
-    const result = await OTPClient.fetchItineraries(from, to, 5);
+    const result = await OTPClient.fetchItineraries(
+      from,
+      to,
+      5,
+      departureTime,
+      departureDate
+    );
     if (result.ok) {
       return Ok(
         result.value.map((otp) => Itinerary.fromOtp(otp, distanceUnits))

--- a/services/frontend/www-app/src/models/Trip.ts
+++ b/services/frontend/www-app/src/models/Trip.ts
@@ -25,7 +25,9 @@ export async function fetchBestTrips(
   from: LngLat,
   to: LngLat,
   mode: TravelMode,
-  distanceUnits: DistanceUnits
+  distanceUnits: DistanceUnits,
+  departureTime?: string,
+  departureDate?: string
 ): Promise<Result<Trip[], TripFetchError>> {
   switch (mode) {
     case TravelMode.Walk:
@@ -40,7 +42,13 @@ export async function fetchBestTrips(
       }
     }
     case TravelMode.Transit: {
-      const result = await Itinerary.fetchBest(from, to, distanceUnits);
+      const result = await Itinerary.fetchBest(
+        from,
+        to,
+        distanceUnits,
+        departureTime,
+        departureDate
+      );
       if (result.ok) {
         return Ok(result.value);
       } else {

--- a/services/frontend/www-app/src/pages/StepsPage.vue
+++ b/services/frontend/www-app/src/pages/StepsPage.vue
@@ -88,7 +88,9 @@ export default defineComponent({
     goToAlternates() {
       const fromEncoded = this.fromPlace?.urlEncodedId() ?? '_';
       const toEncoded = this.toPlace?.urlEncodedId() ?? '_';
-      this.$router.push(`/directions/${this.mode}/${toEncoded}/${fromEncoded}`);
+      let path = `/directions/${this.mode}/${toEncoded}/${fromEncoded}`;
+      let query = this.dateTimeQuery();
+      this.$router.push({ path, query });
     },
 
     rewriteUrl: async function () {
@@ -109,7 +111,9 @@ export default defineComponent({
           this.fromPlace.point,
           this.toPlace.point,
           this.mode,
-          this.fromPlace.preferredDistanceUnits() ?? DistanceUnits.Kilometers
+          this.fromPlace.preferredDistanceUnits() ?? DistanceUnits.Kilometers,
+          this.searchTime,
+          this.searchDate
         );
         if (!result.ok) {
           console.error('fetchBestTrips.error', result.error);
@@ -153,6 +157,16 @@ export default defineComponent({
       }
       map.removeLayersExcept(layerIds);
     },
+    dateTimeQuery(): Record<string, string> {
+      let query: Record<string, string> = {};
+      if (this.searchDate) {
+        query['searchDate'] = this.searchDate;
+      }
+      if (this.searchTime) {
+        query['searchTime'] = this.searchTime;
+      }
+      return query;
+    },
   },
   mounted: async function () {
     this.toPlace = await PlaceStorage.fetchFromSerializedId(
@@ -161,6 +175,12 @@ export default defineComponent({
     this.fromPlace = await PlaceStorage.fetchFromSerializedId(
       this.$props.from as string
     );
+    if (typeof this.$route.query.searchTime == 'string') {
+      this.searchTime = this.$route.query.searchTime;
+    }
+    if (typeof this.$route.query.searchDate == 'string') {
+      this.searchDate = this.$route.query.searchDate;
+    }
 
     await this.rewriteUrl();
 
@@ -199,12 +219,16 @@ export default defineComponent({
     }
   },
   setup: function () {
-    let toPlace: Ref<Place | undefined> = ref(undefined);
-    let fromPlace: Ref<Place | undefined> = ref(undefined);
+    const toPlace: Ref<Place | undefined> = ref(undefined);
+    const fromPlace: Ref<Place | undefined> = ref(undefined);
+    const searchTime: Ref<string | undefined> = ref(undefined);
+    const searchDate: Ref<string | undefined> = ref(undefined);
 
     return {
       toPlace,
       fromPlace,
+      searchTime,
+      searchDate,
     };
   },
 });


### PR DESCRIPTION
Previously transit routing always assumed you wanted to leave right now. Now you can specify the time and date you'd like to depart.



https://user-images.githubusercontent.com/217057/227674057-b848a34e-80ce-467b-81de-c47a962f4c90.mp4

Notes:
- Follow up work would be to add an "arrive by" feature which OTP also supports.
- I'm using the browser native time/date fields because they were expedient. They feel efficient for keyboard users, but might not be very intuitive. We can revisit.
- This should probably be debounced/throttled.
