### PR TITLE
Expose OSM's opening hours

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: earthly/actions-setup@v1
+        with:
+          # pinning to `latest` requires using the GH API, which causes spurious rate limiting errors
+          version: "0.7.4"
       - uses: actions/checkout@v2
       - run: earthly --version
       - run: earthly -P +build --area=Bogota

--- a/.github/workflows/push-dev-containers.yml
+++ b/.github/workflows/push-dev-containers.yml
@@ -11,7 +11,8 @@ jobs:
     steps:
       - uses: earthly/actions-setup@v1
         with:
-          version: "0.7.1"
+          # pinning to `latest` requires using the GH API, which causes spurious rate limiting errors
+          version: "0.7.4"
       - uses: actions/checkout@v2
       - name: Docker login
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u headwaymaps --password-stdin

--- a/.github/workflows/push-latest-containers.yml
+++ b/.github/workflows/push-latest-containers.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: earthly/actions-setup@v1
         with:
           # pinning to `latest` requires using the GH API, which causes spurious rate limiting errors
-          version: "0.7.1"
+          version: "0.7.4"
       - uses: actions/checkout@v2
       - name: Docker login
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u headwaymaps --password-stdin

--- a/services/frontend/www-app/package.json
+++ b/services/frontend/www-app/package.json
@@ -18,6 +18,7 @@
     "@quasar/extras": "^1.0.0",
     "lodash": "^4.17.21",
     "maplibre-gl": "^2.3.0",
+    "opening_hours": "^3.8.0",
     "quasar": "^2.6.0",
     "vite-plugin-rewrite-all": "^1.0.0",
     "vue": "^3.0.0",

--- a/services/frontend/www-app/src/boot/i18n.ts
+++ b/services/frontend/www-app/src/boot/i18n.ts
@@ -6,10 +6,17 @@ export default ({ app }: { app: App }) => {
   app.use(createI18nForApp());
 };
 
-export const createI18nForApp = () =>
-  createI18n({
-    locale: navigator.language,
+export const createI18nForApp = () => {
+  let locale;
+  if (process.env.NODE_ENV == 'test') {
+    locale = 'en-US';
+  } else {
+    locale = navigator.language;
+  }
+  return createI18n({
+    locale,
     fallbackLocale: 'en-US',
     globalInjection: true,
     messages,
   });
+};

--- a/services/frontend/www-app/src/components/OpeningHoursStatus.vue
+++ b/services/frontend/www-app/src/components/OpeningHoursStatus.vue
@@ -1,0 +1,73 @@
+<template>
+  <span v-if="openingHours.isOpen">
+    <span v-if="openingHours.nextChange">
+      {{
+        openingHours.nextChangeIsToday
+          ? $t('opening_hours_is_open_until_$time', {
+              time: formattedTime,
+            })
+          : openingHours.nextChangeIsTomorrow
+          ? $t('opening_hours_is_open_until_tomorrow$time', {
+              time: formattedTime,
+            })
+          : $t('opening_hours_is_open_until_later_$day_$time', {
+              time: formattedTime,
+              day: dayOfWeek(openingHours.nextChange),
+            })
+      }}
+    </span>
+    <span v-else>
+      {{ $t('opening_hours_is_open') }}
+    </span>
+  </span>
+
+  <span v-else>
+    <span v-if="openingHours.nextChange">
+      {{
+        openingHours.nextChangeIsToday
+          ? $t('opening_hours_is_closed_until_$time', {
+              time: formattedTime,
+            })
+          : openingHours.nextChangeIsTomorrow
+          ? $t('opening_hours_is_closed_until_tomorrow_$time', {
+              time: formattedTime,
+            })
+          : $t('opening_hours_is_closed_until_later_$day_$time', {
+              time: formattedTime,
+              day: dayOfWeek(openingHours.nextChange),
+            })
+      }}
+    </span>
+    <span v-else>
+      {{ $t('opening_hours_is_closed') }}
+    </span>
+  </span>
+</template>
+
+<script lang="ts">
+import OpeningHours from 'src/models/OpeningHours';
+import { defineComponent, PropType } from 'vue';
+import { formatTimeTruncatingEmptyMinutes, dayOfWeek } from 'src/utils/format';
+
+export default defineComponent({
+  name: 'OpeningHoursStatus',
+  props: {
+    openingHours: {
+      type: Object as PropType<OpeningHours>,
+      required: true,
+    },
+  },
+  data(): {
+    formattedTime?: string;
+  } {
+    return {
+      formattedTime: this.openingHours.nextChange
+        ? formatTimeTruncatingEmptyMinutes(this.openingHours.nextChange)
+        : undefined,
+    };
+  },
+  methods: {
+    dayOfWeek,
+  },
+});
+</script>

--- a/services/frontend/www-app/src/components/OpeningHoursStatus.vue
+++ b/services/frontend/www-app/src/components/OpeningHoursStatus.vue
@@ -57,14 +57,14 @@ export default defineComponent({
       required: true,
     },
   },
-  data(): {
-    formattedTime?: string;
-  } {
-    return {
-      formattedTime: this.openingHours.nextChange
-        ? formatTimeTruncatingEmptyMinutes(this.openingHours.nextChange)
-        : undefined,
-    };
+  computed: {
+    formattedTime(): string | undefined {
+      if (this.openingHours.nextChange) {
+        return formatTimeTruncatingEmptyMinutes(this.openingHours.nextChange);
+      } else {
+        return undefined;
+      }
+    },
   },
   methods: {
     dayOfWeek,

--- a/services/frontend/www-app/src/components/OpeningHoursTable.vue
+++ b/services/frontend/www-app/src/components/OpeningHoursTable.vue
@@ -1,0 +1,59 @@
+<template>
+  <table>
+    <tr
+      v-for="dayRange in openingHours.weeklyRanges()"
+      v-bind:key="JSON.stringify(dayRange)"
+    >
+      <td>{{ dayRange.day }}</td>
+      <td>
+        <ul class="opening-hours" v-if="dayRange.intervals.length > 0">
+          <li
+            v-for="interval in dayRange.intervals"
+            v-bind:key="JSON.stringify(interval)"
+          >
+            {{ formatTimeTruncatingEmptyMinutes(interval[0]) }}
+            -
+            {{ formatTimeTruncatingEmptyMinutes(interval[1]) }}
+          </li>
+        </ul>
+        <ul class="opening-hours" v-else>
+          <li>
+            {{ $t('opening_hours_is_closed') }}
+          </li>
+        </ul>
+      </td>
+    </tr>
+  </table>
+</template>
+
+<style lang="scss">
+ul.opening-hours {
+  margin-block-start: 2px;
+  margin-block-end: 2px;
+  list-style: none;
+}
+
+// bold "today"
+tr:first-child {
+  font-weight: bold;
+}
+</style>
+
+<script lang="ts">
+import OpeningHours from 'src/models/OpeningHours';
+import { defineComponent, PropType } from 'vue';
+import { formatTimeTruncatingEmptyMinutes } from 'src/utils/format';
+
+export default defineComponent({
+  name: 'OpeningHoursTable',
+  props: {
+    openingHours: {
+      type: Object as PropType<OpeningHours>,
+      required: true,
+    },
+  },
+  methods: {
+    formatTimeTruncatingEmptyMinutes,
+  },
+});
+</script>

--- a/services/frontend/www-app/src/components/PlaceCard.vue
+++ b/services/frontend/www-app/src/components/PlaceCard.vue
@@ -1,7 +1,7 @@
 <template>
   <q-card-section>
     <div class="text-subtitle1">
-      {{ primaryName() }}
+      {{ primaryName }}
     </div>
   </q-card-section>
   <q-card-section>
@@ -9,20 +9,20 @@
   </q-card-section>
   <q-card-section>
     <place-field
-      v-if="secondaryName()"
-      :copy-text="secondaryName()!"
+      v-if="secondaryName"
+      :copy-text="secondaryName"
       icon="location_on"
     >
-      {{ secondaryName() }}
+      {{ secondaryName }}
     </place-field>
-    <place-field v-if="website()" :copy-text="website()!" icon="public">
-      <a :href="website()">{{ website() }}</a>
+    <place-field v-if="website" :copy-text="website" icon="public">
+      <a :href="website">{{ website }}</a>
     </place-field>
-    <place-field v-if="phone()" :copy-text="phone()!" icon="phone">
-      <a :href="'tel:' + phone()">{{ phone() }}</a>
+    <place-field v-if="phone" :copy-text="phone" icon="phone">
+      <a :href="'tel:' + phone">{{ phone }}</a>
     </place-field>
-    <place-field v-if="openingHours()" icon="access_time">
-      <opening-hours-status :opening-hours="openingHours()!" />
+    <place-field v-if="openingHours" icon="access_time">
+      <opening-hours-status :opening-hours="openingHours" />
       <q-btn
         flat
         size="sm"
@@ -37,11 +37,11 @@
         }}
       </q-btn>
     </place-field>
-    <place-field v-if="openingHours() && showMoreOpeningHours" icon="none">
-      <opening-hours-table :opening-hours="openingHours()!" />
+    <place-field v-if="openingHours && showMoreOpeningHours" icon="none">
+      <opening-hours-table :opening-hours="openingHours" />
     </place-field>
     <div
-      v-if="isEditable()"
+      v-if="isEditable"
       :style="{
         margin: '8px -16px',
         padding: '8px 16px',
@@ -61,7 +61,7 @@
             flat
             :ripple="false"
             icon-right="launch"
-            :href="osmEditUrl()"
+            :href="osmEditUrl"
             >{{ $t('edit_poi_on_osm_button') }}</q-btn
           >
         </div>
@@ -112,6 +112,8 @@ export default defineComponent({
     didToggleShowMoreOpeningHours() {
       this.showMoreOpeningHours = !this.showMoreOpeningHours;
     },
+  },
+  computed: {
     primaryName(): string {
       if (this.place.name) {
         return this.place.name;
@@ -138,11 +140,10 @@ export default defineComponent({
     openingHours(): OpeningHours | undefined {
       if (this.place.openingHours) {
         try {
-          const openingHours = OpeningHours.fromOsmString(
+          return OpeningHours.fromOsmString(
             this.place.openingHours,
             this.rightNow
           );
-          return openingHours;
         } catch (error) {
           console.warn(
             'Error parsing opening hours',
@@ -151,9 +152,10 @@ export default defineComponent({
           );
         }
       }
+      return undefined;
     },
     isEditable(): boolean {
-      return !!this.osmEditUrl();
+      return !!this.osmEditUrl;
     },
     osmEditUrl(): string | undefined {
       try {

--- a/services/frontend/www-app/src/components/PlaceField.vue
+++ b/services/frontend/www-app/src/components/PlaceField.vue
@@ -7,10 +7,15 @@
     <q-btn
       class="col-1"
       icon="content_copy"
+      v-if="copyText"
       unelevated
       :ripple="false"
       size="sm"
-      @click="copyToClipboard(copyText)"
+      @click="
+        if (copyText) {
+          copyToClipboard(copyText);
+        }
+      "
     />
   </q-item>
 </template>
@@ -25,10 +30,7 @@ export default defineComponent({
       type: String,
       required: true,
     },
-    copyText: {
-      type: String,
-      required: true,
-    },
+    copyText: String,
   },
   methods: {
     copyToClipboard(text: string): void {

--- a/services/frontend/www-app/src/i18n/en-US/index.ts
+++ b/services/frontend/www-app/src/i18n/en-US/index.ts
@@ -61,4 +61,14 @@ export default {
   edit_poi_on_osm_button: 'Edit on OpenStreetMap',
   edit_poi_about_osm:
     'This data is from OpenStreetMap, a community maintained mapping project. You can edit OpenStreetMap, and your edits will eventually be reflected here.',
+  opening_hours_is_open: 'Open',
+  opening_hours_is_open_until_$time: 'Open until {time}',
+  opening_hours_is_open_until_later_$day_$time: 'Open until {time} {day}',
+  opening_hours_is_open_until_tomorrow_$time: 'Open until {time} tomorrow',
+  opening_hours_is_closed: 'Closed',
+  opening_hours_is_closed_until_$time: 'Closed until {time}',
+  opening_hours_is_closed_until_later_$day_$time: 'Closed until {time} {day}',
+  opening_hours_is_closed_until_tomorrow_$time: 'Closed until {time} tomorrow',
+  opening_hours_show_more_times: 'Show hours',
+  opening_hours_hide_more_times: 'Hide hours',
 };

--- a/services/frontend/www-app/src/models/OpeningHours.test.ts
+++ b/services/frontend/www-app/src/models/OpeningHours.test.ts
@@ -1,0 +1,85 @@
+import { expect, test } from '@jest/globals';
+import OpeningHours from './OpeningHours';
+import { formatTime } from '../utils/format';
+
+const sundayMorning = new Date('2012/11/11 8:00 AM');
+const mondayMorning = new Date('2012/11/12 8:00 AM');
+const tuesdayMorning = new Date('2012/11/13 8:00 AM');
+
+test('is open', () => {
+  const osmText = 'Su-Th 08:00-21:00; Fr-Sa 08:00-22:00';
+  let hours = OpeningHours.fromOsmString(
+    osmText,
+    new Date('2012/11/11 7:59 AM')
+  );
+  expect(hours.isOpen).toBe(false);
+
+  hours = OpeningHours.fromOsmString(osmText, new Date('2012/11/11 8:00 AM'));
+  expect(hours.isOpen).toBe(true);
+
+  hours = OpeningHours.fromOsmString(osmText, new Date('2012/11/11 8:59 PM'));
+  expect(hours.isOpen).toBe(true);
+
+  hours = OpeningHours.fromOsmString(osmText, new Date('2012/11/11 9:00 PM'));
+  expect(hours.isOpen).toBe(false);
+});
+
+test('weeklyRanges', () => {
+  const hours = OpeningHours.fromOsmString(
+    'Su-Th 08:00-21:00; Fr-Sa 08:00-22:00',
+    sundayMorning
+  );
+  expect(hours.nextChange!.getHours()).toBe(21);
+
+  const ranges = hours.weeklyRanges();
+  expect(ranges.length).toBe(7);
+
+  const days = ranges.map((dayInterval) => dayInterval.day);
+  expect(days).toEqual(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']);
+
+  for (const dayInterval of ranges) {
+    expect(dayInterval.intervals.length).toBe(1);
+    const interval = dayInterval.intervals[0];
+    switch (dayInterval.day) {
+      case 'Sun':
+      case 'Mon':
+      case 'Tue':
+      case 'Wed':
+      case 'Thu':
+        expect(formatTime(interval[0])).toBe('8:00 AM');
+        expect(formatTime(interval[1])).toBe('9:00 PM');
+        break;
+      case 'Fri':
+      case 'Sat':
+        expect(formatTime(interval[0])).toBe('8:00 AM');
+        expect(formatTime(interval[1])).toBe('10:00 PM');
+        break;
+      default:
+        throw new Error(`unexpected day ${dayInterval.day}`);
+    }
+  }
+});
+
+test('nextChange - closed today and tomorrow', () => {
+  const osmText = 'Su-Mo off; Tu-Sa 11:00-15:00,17:00-21:00';
+  const hours = OpeningHours.fromOsmString(osmText, sundayMorning);
+  expect(hours.nextChangeIsToday!).toBe(false);
+  expect(hours.nextChangeIsTomorrow!).toBe(false);
+  expect(hours.nextChange!.getHours()).toBe(11);
+});
+
+test('nextChange - closed until tomorrow morning', () => {
+  const osmText = 'Su-Mo off; Tu-Sa 11:00-15:00,17:00-21:00';
+  const hours = OpeningHours.fromOsmString(osmText, mondayMorning);
+  expect(hours.nextChangeIsToday!).toBe(false);
+  expect(hours.nextChangeIsTomorrow!).toBe(true);
+  expect(hours.nextChange!.getHours()).toBe(11);
+});
+
+test('nextChange - closed until later this morning', () => {
+  const osmText = 'Su-Mo off; Tu-Sa 11:00-15:00,17:00-21:00';
+  const hours = OpeningHours.fromOsmString(osmText, tuesdayMorning);
+  expect(hours.nextChangeIsToday!).toBe(true);
+  expect(hours.nextChangeIsTomorrow!).toBe(false);
+  expect(hours.nextChange!.getHours()).toBe(11);
+});

--- a/services/frontend/www-app/src/models/OpeningHours.ts
+++ b/services/frontend/www-app/src/models/OpeningHours.ts
@@ -1,0 +1,70 @@
+import ParsedOpeningHours from 'opening_hours';
+
+export default class OpeningHours {
+  parsed: ParsedOpeningHours;
+  now: Date;
+  isOpen: boolean;
+  nextChange?: Date;
+
+  constructor(parsed: ParsedOpeningHours, now: Date) {
+    this.parsed = parsed;
+    this.now = now;
+    const statePair = parsed.getStatePair(now);
+    this.isOpen = statePair[0];
+
+    let stepIdx = 0;
+    let prevStatePair = statePair;
+    let nextStatePair = parsed.getStatePair(prevStatePair[1]);
+    while (nextStatePair[0] == this.isOpen && stepIdx < 10) {
+      stepIdx++;
+      prevStatePair = nextStatePair;
+      nextStatePair = parsed.getStatePair(prevStatePair[1]);
+    }
+    if (stepIdx == 10) {
+      console.error('found seemingly unchanging opening hours');
+    } else {
+      this.nextChange = prevStatePair[1];
+    }
+  }
+
+  static fromOsmString(osmString: string, now: Date): OpeningHours {
+    const parsed = new ParsedOpeningHours(osmString);
+    return new OpeningHours(parsed, now);
+  }
+
+  weeklyRanges(): DayInterval[] {
+    const days: DayInterval[] = [];
+    for (let dayIdx = 0; dayIdx < 7; dayIdx++) {
+      const startOfDay = new Date(this.now);
+      startOfDay.setHours(0, 0, 0, 0);
+      startOfDay.setDate(startOfDay.getDate() + dayIdx);
+
+      const endOfDay = new Date(startOfDay);
+      endOfDay.setHours(23, 59, 59, 999);
+      const dayName = startOfDay.toLocaleString([], { weekday: 'short' });
+      const intervals: Interval[] = this.parsed.getOpenIntervals(
+        startOfDay,
+        endOfDay
+      );
+
+      days.push({ day: dayName, intervals });
+    }
+    return days;
+  }
+
+  get nextChangeIsToday(): boolean | undefined {
+    if (this.nextChange) {
+      return this.nextChange.getDate() == this.now.getDate();
+    }
+  }
+
+  get nextChangeIsTomorrow(): boolean | undefined {
+    if (this.nextChange) {
+      return this.nextChange.getDate() - this.now.getDate() == 1;
+    }
+  }
+}
+
+type Interval = [Date, Date, boolean, string | undefined];
+
+type DayInterval = { day: string; intervals: Interval[] };

--- a/services/frontend/www-app/src/models/Place.ts
+++ b/services/frontend/www-app/src/models/Place.ts
@@ -150,6 +150,7 @@ type PlaceProperties = {
   address?: string;
   phone?: string;
   website?: string;
+  openingHours?: string;
 };
 
 /// Wrapper around a pelias response
@@ -162,6 +163,7 @@ export default class Place {
   name?: string;
   public phone?: string;
   public website?: string;
+  public openingHours?: string;
 
   constructor(
     id: PlaceId,
@@ -177,6 +179,7 @@ export default class Place {
     this.address = props.address;
     this.phone = props.phone;
     this.website = props.website;
+    this.openingHours = props.openingHours;
   }
 
   static fromFeature(id: PlaceId, feature: GeoJSON.Feature): Place {
@@ -240,6 +243,7 @@ export default class Place {
     // }
     const website = feature.properties?.addendum?.osm?.website;
     const phone = feature.properties?.addendum?.osm?.phone;
+    const openingHours = feature.properties?.addendum?.osm?.opening_hours;
 
     const place = new Place(id, location, bbox, {
       countryCode,
@@ -247,6 +251,7 @@ export default class Place {
       address,
       website,
       phone,
+      openingHours,
     });
     return place;
   }

--- a/services/frontend/www-app/src/utils/format.ts
+++ b/services/frontend/www-app/src/utils/format.ts
@@ -73,8 +73,27 @@ export function formatLngLatAsLatLng(point: LngLatLike): string {
   return `${fmt(lngLat.lat)}°${northOrSouth}, ${fmt(lngLat.lng)}°${eastOrWest}`;
 }
 
-export function formatTime(millis: number): string {
-  return new Date(millis).toLocaleTimeString([], { timeStyle: 'short' });
+export function formatTime(dateArgs: number | string | Date): string {
+  return new Date(dateArgs).toLocaleTimeString([], { timeStyle: 'short' });
+}
+
+/**
+ * Very concise time formatting
+ *
+ * 10:00 AM -> 10 AM
+ * 10:01 AM -> 10:01 AM (unchanged when minutes are non-zero)
+ */
+export function formatTimeTruncatingEmptyMinutes(
+  dateArgs: number | string | Date
+): string {
+  // This is admittedly a hack, and probably doesn't won't improve some
+  // localizations, but I don't know of a better way that doesn't break other
+  // localizations.
+  return formatTime(dateArgs).replace(':00', '');
+}
+
+export function dayOfWeek(dateArgs: number | string | Date): string {
+  return new Date(dateArgs).toLocaleString([], { weekday: 'short' });
 }
 
 export function kilometersToMiles(kilometers: number): number {

--- a/services/frontend/www-app/yarn.lock
+++ b/services/frontend/www-app/yarn.lock
@@ -260,6 +260,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.19.0"
 
+"@babel/runtime@^7.17.2", "@babel/runtime@^7.19.0":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
+  integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/template@^7.20.7", "@babel/template@^7.3.3":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
@@ -2850,6 +2857,20 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+i18next-browser-languagedetector@^6.1.4:
+  version "6.1.8"
+  resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-6.1.8.tgz#8e9c61b32a4dfe9b959b38bc9d2a8b95f799b27c"
+  integrity sha512-Svm+MduCElO0Meqpj1kJAriTC6OhI41VhlT/A0UPjGoPZBhAHIaGE5EfsHlTpgdH09UVX7rcc72pSDDBeKSQQA==
+  dependencies:
+    "@babel/runtime" "^7.19.0"
+
+i18next@^21.8.3:
+  version "21.10.0"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-21.10.0.tgz#85429af55fdca4858345d0e16b584ec29520197d"
+  integrity sha512-YeuIBmFsGjUfO3qBmMOc0rQaun4mIpGKET5WDwvu8lU7gvwpcariZLNtL0Fzj+zazcHUrlXHiptcFhBMFaxzfg==
+  dependencies:
+    "@babel/runtime" "^7.17.2"
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -3923,6 +3944,15 @@ open@^8.4.0:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
+opening_hours@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/opening_hours/-/opening_hours-3.8.0.tgz#e6d0a0bfd4e0f2cb8f62321e468dcaa8a798bd79"
+  integrity sha512-bRJroECQSe/itVcNmC3j9PPicxn/LBowdd1Hi+4Aa7hCswdt7w81WHfUwrEMbtk1BBYmGJEbSepl8oYYPviSuA==
+  dependencies:
+    i18next "^21.8.3"
+    i18next-browser-languagedetector "^6.1.4"
+    suncalc "^1.9.0"
+
 optionator@^0.9.1:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
@@ -4253,6 +4283,11 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+regenerator-runtime@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 regexpp@^3.2.0:
   version "3.2.0"
@@ -4602,6 +4637,11 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+suncalc@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/suncalc/-/suncalc-1.9.0.tgz#26212353fae61edb287c2d558fc4932ecf0e1532"
+  integrity sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A==
 
 supercluster@^7.1.5:
   version "7.1.5"


### PR DESCRIPTION
<img width="386" alt="Screenshot 2023-04-24 at 15 16 14" src="https://user-images.githubusercontent.com/217057/234118767-0ac1caa2-d98d-4666-99e9-e282009dee81.png">

After you tap/click "show hours"
<img width="439" alt="Screenshot 2023-04-24 at 15 16 26" src="https://user-images.githubusercontent.com/217057/234118760-848fa146-c759-4f13-a4f2-bdee349f5683.png">

A more complicated one:
<img width="389" alt="Screenshot 2023-04-24 at 15 18 01" src="https://user-images.githubusercontent.com/217057/234119121-4c12ae63-e66d-44fc-b8e0-e7ec87b88e17.png">

Note that the current "status" (whether it's "open until..." or "closed until..." ) assumes you're looking at places only within your own timezone, which is obviously flawed.

I think addressing that might be non-trivial. Maybe we could plumb the timezone of each place through pelias? As it is, I believe it's the common case that people are looking for hours in their own timezone, and thus useful enough to include, even with this limitation.