### PR TITLE
Show place details as you click through search results

### DIFF
--- a/services/frontend/www-app/src/components/MultiModalSteps.vue
+++ b/services/frontend/www-app/src/components/MultiModalSteps.vue
@@ -127,7 +127,7 @@ export default defineComponent({
     formatTime,
     formatDuration,
     clickedStep: (step: Step): void => {
-      getBaseMap()?.flyTo(step.position, 16);
+      getBaseMap()?.flyTo(step.position, { zoom: 16 });
     },
   },
 });

--- a/services/frontend/www-app/src/components/PlaceCard.vue
+++ b/services/frontend/www-app/src/components/PlaceCard.vue
@@ -79,7 +79,7 @@
 </template>
 <style lang="scss">
 // mobile layout
-@media screen and (max-width: 800px) {
+@media screen and (max-width: 799px) {
   .title-bar {
     flex-direction: row-reverse;
   }

--- a/services/frontend/www-app/src/components/PlaceCard.vue
+++ b/services/frontend/www-app/src/components/PlaceCard.vue
@@ -1,7 +1,17 @@
 <template>
   <q-card-section>
-    <div class="text-subtitle1">
-      {{ primaryName }}
+    <div class="text-subtitle1 title-bar" style="display: flex">
+      <span style="flex: 1">{{ primaryName }}</span>
+      <q-btn
+        v-if="didPressClose"
+        class="close-btn"
+        size="sm"
+        round
+        unelevated
+        :ripple="false"
+        :icon="backIcon()"
+        @click="() => didPressClose!()"
+      />
     </div>
   </q-card-section>
   <q-card-section>
@@ -43,8 +53,6 @@
     <div
       v-if="isEditable"
       :style="{
-        margin: '8px -16px',
-        padding: '8px 16px',
         backgroundColor: showEditPanel ? '#eaeaea' : undefined,
       }"
     >
@@ -69,6 +77,14 @@
     </div>
   </q-card-section>
 </template>
+<style lang="scss">
+// mobile layout
+@media screen and (max-width: 800px) {
+  .title-bar {
+    flex-direction: row-reverse;
+  }
+}
+</style>
 
 <script lang="ts">
 import { i18n } from 'src/i18n/lang';
@@ -89,6 +105,7 @@ export default defineComponent({
       type: Place,
       required: true,
     },
+    didPressClose: Function,
   },
   data(): {
     rightNow: Date;
@@ -106,6 +123,15 @@ export default defineComponent({
     };
   },
   methods: {
+    backIcon(): string {
+      if (this.$q.platform.is.desktop) {
+        return 'close';
+      } else if (this.$q.platform.is.ios) {
+        return 'arrow_back_ios';
+      } else {
+        return 'arrow_back';
+      }
+    },
     didToggleEdit(): void {
       this.showEditPanel = !this.showEditPanel;
     },

--- a/services/frontend/www-app/src/components/PlaceCard.vue
+++ b/services/frontend/www-app/src/components/PlaceCard.vue
@@ -124,9 +124,9 @@ export default defineComponent({
   },
   methods: {
     backIcon(): string {
-      if (this.$q.platform.is.desktop) {
+      if (this.$q.screen.md) {
         return 'close';
-      } else if (this.$q.platform.is.ios) {
+      } else if (this.$q.platform.is.mac || this.$q.platform.is.ios) {
         return 'arrow_back_ios';
       } else {
         return 'arrow_back';

--- a/services/frontend/www-app/src/components/SearchListItem.vue
+++ b/services/frontend/www-app/src/components/SearchListItem.vue
@@ -7,19 +7,16 @@
       <q-item-label class="text-weight-light">
         {{ place.address }}
       </q-item-label>
-      <travel-mode-bar :to-place="place" :hidden="!active" class="q-mt-sm" />
     </q-item-section>
   </q-item>
 </template>
 
 <script lang="ts">
 import Place from 'src/models/Place';
-import TravelModeBar from 'src/components/TravelModeBar.vue';
 import { defineComponent, PropType } from 'vue';
 
 export default defineComponent({
   name: 'SearchListItem',
-  components: { TravelModeBar },
   props: {
     place: {
       type: Object as PropType<Place>,

--- a/services/frontend/www-app/src/components/SingleModeSteps.vue
+++ b/services/frontend/www-app/src/components/SingleModeSteps.vue
@@ -60,7 +60,7 @@ export default defineComponent({
     clickedManeuver: function (maneuver: ValhallaRouteLegManeuver) {
       const location = this.geometry.coordinates[maneuver.begin_shape_index];
       let coord: [number, number] = [location[0], location[1]];
-      getBaseMap()?.flyTo(coord, 16);
+      getBaseMap()?.flyTo(coord, { zoom: 16 });
     },
   },
 });

--- a/services/frontend/www-app/src/layouts/MainLayout.vue
+++ b/services/frontend/www-app/src/layouts/MainLayout.vue
@@ -8,7 +8,7 @@
 <style lang="scss">
 .platform-ios {
   .app-container {
-    @media screen and (max-width: 800px) {
+    @media screen and (max-width: 799px) {
       height: -webkit-fill-available;
     }
   }
@@ -28,7 +28,7 @@
 
 .top-card {
   border-bottom: solid #ccc 1px;
-  @media screen and (max-width: 800px) {
+  @media screen and (max-width: 799px) {
     order: 1;
 
     box-shadow: 0px 0px 5px #00000088;
@@ -46,7 +46,7 @@
 
 .bottom-card {
   overflow-y: scroll;
-  @media screen and (max-width: 800px) {
+  @media screen and (max-width: 799px) {
     order: 3;
     width: 100%;
     box-shadow: 0px 0px 5px #00000088;
@@ -73,7 +73,7 @@
 #map {
   z-index: 0;
 
-  @media screen and (max-width: 800px) {
+  @media screen and (max-width: 799px) {
     // This is tall enough to keep the map UI from overlapping.
     // Ironically the "wide"/"desktop" layout is slightly less tall than the
     // "mobile optimized" layout, which only needs about 170px

--- a/services/frontend/www-app/src/layouts/MainLayout.vue
+++ b/services/frontend/www-app/src/layouts/MainLayout.vue
@@ -115,5 +115,8 @@ export default defineComponent({
     appClass: String,
   },
   components: { BaseMap },
+  mounted() {
+    this.$q.screen.setSizes({ md: 800 });
+  },
 });
 </script>

--- a/services/frontend/www-app/src/pages/BaseMapPage.vue
+++ b/services/frontend/www-app/src/pages/BaseMapPage.vue
@@ -15,7 +15,7 @@
 // override some styles from the default layout.
 .front-page {
   .top-card {
-    @media screen and (max-width: 800px) {
+    @media screen and (max-width: 799px) {
       width: 100%;
       padding: 16px;
       border-bottom: solid #ccc 1px;

--- a/services/frontend/www-app/src/pages/SearchPage.vue
+++ b/services/frontend/www-app/src/pages/SearchPage.vue
@@ -7,10 +7,7 @@
     />
   </div>
 
-  <div
-    :class="'bottom-card' + (selectedPlace ? ' selected-place' : '')"
-    ref="bottomCard"
-  >
+  <div class="bottom-card" ref="bottomCard">
     <q-linear-progress v-if="isLoading" indeterminate />
     <div class="selected-place-card" v-if="selectedPlace">
       <place-card
@@ -23,7 +20,7 @@
         "
       />
     </div>
-    <q-list class="search-results">
+    <q-list class="search-results" v-if="$q.screen.md || !selectedPlace">
       <search-list-item
         v-for="place in searchResults?.places"
         v-bind:key="place.id.serialized()"
@@ -40,19 +37,9 @@
 </template>
 
 <style lang="scss">
-.selected-place .search-results {
-  @media screen and (max-width: 799px) {
-    // hide search results while showing selected place on mobile
-    display: none;
-  }
-}
-
 .selected-place-card {
-  @media screen and (max-width: 799px) {
-    // on mobile
-  }
   @media screen and (min-width: 800px) {
-    // on desktop
+    // on "desktop" layout
     position: absolute;
     z-index: 1;
     left: var(--left-panel-width);
@@ -126,16 +113,21 @@ export default defineComponent({
 
       let options: FlyToOptions | undefined;
 
-      // This abuses the fact that the "selected place card" is the same
-      // width as the bottomCard. We could use $refs.selectedPlaceCard,
-      // but it might not be visible to measure yet.
-      if (this.$refs.bottomCard) {
-        let placeCard: HTMLElement = this.$refs.bottomCard as HTMLElement;
-        let xOffset = placeCard.offsetWidth / 2;
+      if (!this.$refs.bottomCard) {
+        console.error('bottomCard was unset');
+        return;
+      }
+
+      let bottomCard: HTMLElement = this.$refs.bottomCard as HTMLElement;
+      if (this.$q.screen.md) {
+        // This abuses the fact that the "selected place card" is the same
+        // width as the bottomCard. We could use $refs.selectedPlaceCard,
+        // but it might not be visible to measure yet.
+        let xOffset = bottomCard.offsetWidth;
         if (place.bbox) {
-          options = { offset: [xOffset / 2, 0] };
+          options = { offset: [xOffset / 4, 0] };
         } else {
-          options = { offset: [xOffset, 0] };
+          options = { offset: [xOffset / 2, 0] };
         }
       }
       map.flyToPlace(place, options);

--- a/services/frontend/www-app/src/pages/SearchPage.vue
+++ b/services/frontend/www-app/src/pages/SearchPage.vue
@@ -41,14 +41,14 @@
 
 <style lang="scss">
 .selected-place .search-results {
-  @media screen and (max-width: 800px) {
+  @media screen and (max-width: 799px) {
     // hide search results while showing selected place on mobile
     display: none;
   }
 }
 
 .selected-place-card {
-  @media screen and (max-width: 800px) {
+  @media screen and (max-width: 799px) {
     // on mobile
   }
   @media screen and (min-width: 800px) {

--- a/services/frontend/www-app/src/pages/StepsPage.vue
+++ b/services/frontend/www-app/src/pages/StepsPage.vue
@@ -27,7 +27,7 @@
 
 <style lang="scss">
 .steps-page-bottom-card {
-  @media screen and (max-width: 800px) {
+  @media screen and (max-width: 799px) {
     max-height: calc(100% - 350px);
   }
 }


### PR DESCRIPTION
This change affects the search page, e.g. https://maps.earth/search/coffee

**before**
<img width="1158" alt="Screenshot 2023-05-03 at 15 01 05" src="https://user-images.githubusercontent.com/217057/236059596-41839ecf-fb00-4b00-a317-7119f13aaf91.png">

Previously, only name and address were surfaced. 

**After**
Now we show open hours and the other POI information we have in a separate card.  On desktop this card floats, on mobile the card replaces the search results, but you can quickly go "back" to the search results to keep browsing.

<img width="940" alt="Screenshot 2023-05-03 at 14 57 11" src="https://user-images.githubusercontent.com/217057/236059602-e71cd97a-7e32-4704-8a2b-81fb756e6592.png">

<img width="564" alt="Screenshot 2023-05-03 at 14 56 50" src="https://user-images.githubusercontent.com/217057/236059607-58fd1e4e-26a8-4f59-947c-cd6578e163d1.png">


Also:
- fixed an off-by-one error when the browser was the exact breakpoint width.
- you now zoom out when "deselecting" a search result.