### PR TITLE
transit timeline design tweaks

### DIFF
--- a/services/frontend/www-app/src/components/MultiModalListItem.vue
+++ b/services/frontend/www-app/src/components/MultiModalListItem.vue
@@ -2,7 +2,7 @@
   <q-item-label>
     {{ trip.startStopTimesFormatted() }}
   </q-item-label>
-  <q-item-label caption>
+  <q-item-label>
     {{ trip.viaRouteFormatted }}
   </q-item-label>
   <q-item-label caption :hidden="!active">

--- a/services/frontend/www-app/src/models/Itinerary.ts
+++ b/services/frontend/www-app/src/models/Itinerary.ts
@@ -160,7 +160,7 @@ export default class Itinerary implements Trip {
   }
 
   public get viaRouteFormatted(): string | undefined {
-    return this.legs.map((leg) => leg.shortName).join('→');
+    return this.legs.map((leg) => leg.shortName).join(' → ');
   }
 
   public get bounds(): LngLatBounds {


### PR DESCRIPTION
- [www] Fix: transit timeline to faint in Chrome
- [www] arrows in transit timeline were too crowded

**before**
<img width="429" alt="Screenshot 2023-05-09 at 11 16 40" src="https://github.com/headwaymaps/headway/assets/217057/4b191e2f-3c35-4df4-ae12-2b9ba2341014">


**after**
<img width="427" alt="Screenshot 2023-05-09 at 11 16 17" src="https://github.com/headwaymaps/headway/assets/217057/d71c77a2-6bc8-42ac-9fe9-daa5b5ec0743">


