### PR TITLE
[www] render 3-d buildings

### DIFF
--- a/services/frontend/www-app/quasar.config.js
+++ b/services/frontend/www-app/quasar.config.js
@@ -100,8 +100,10 @@ module.exports = configure(function (/* ctx */) {
       open: true, // opens browser window automatically
       proxy: {
         '/tileserver': {
-          target: HEADWAY_HOST,
           changeOrigin: true,
+          target: HEADWAY_HOST,
+          // target: 'http://localhost:8000',
+          // rewrite: (path) => path.replace(/^\/tileserver/, ''),
         },
         '/pelias': {
           target: HEADWAY_HOST,


### PR DESCRIPTION
3d buildings are neat, but especially with very tall buildings they can obscure useful parts of the map.

Opacity is one way of dealing with this, but even with opacity, things get obscured and IMO they look noisier.

Another option would be to add a toggle to the screen to enable/disable the 3d effect, but I don't like the idea of taking up more screen real estate for yet another button. Better would be to do something by default that (most) people (mostly) like.

So I chose to only show the 3d buildings when zoomed in substantially, and I dampened the height of buildings to minimize how much they'd "bleed" into the map. My hope is that it's a subtle thing that enriches the map, helping to orient people, without being too distracting.


https://github.com/headwaymaps/headway/assets/217057/db76e8bf-2550-4511-8615-c77e97057fb9

<img width="1072" alt="Screenshot 2023-05-25 at 15 45 45" src="https://github.com/headwaymaps/headway/assets/217057/05f2807a-2932-4cf1-bd9b-f3919fcd13e7">

<img width="1072" alt="Screenshot 2023-05-25 at 15 44 52" src="https://github.com/headwaymaps/headway/assets/217057/309914f6-ff2e-4f5c-bfaa-9d1edefcb23d">