### PR TITLE
"No search results" instead of blank text

### DIFF
--- a/services/frontend/www-app/src/i18n/en-US/index.ts
+++ b/services/frontend/www-app/src/i18n/en-US/index.ts
@@ -76,4 +76,7 @@ export default {
   opening_hours_is_closed_until_tomorrow_$time: 'Closed until {time} tomorrow',
   opening_hours_show_more_times: 'Show hours',
   opening_hours_hide_more_times: 'Hide hours',
+  search_results_not_found_header: 'No results found. 😢',
+  search_results_not_found_subheader:
+    'Something missing? Consider adding it to {osmLink} so it can eventually appear here.',
 };

--- a/services/frontend/www-app/src/pages/SearchPage.vue
+++ b/services/frontend/www-app/src/pages/SearchPage.vue
@@ -32,6 +32,25 @@
         v-on:mouseleave="didHoverSearchListItem(undefined)"
         v-on:click="didClickSearchListItem(place)"
       />
+      <q-item
+        class="list-item"
+        v-if="searchResults?.places.length === 0 && !isLoading"
+      >
+        <q-item-section>
+          <q-item-label>
+            {{ $t('search_results_not_found_header') }}
+          </q-item-label>
+          <q-item-label
+            class="text-weight-light"
+            v-html="
+              $t('search_results_not_found_subheader', {
+                osmLink:
+                  '<a href=https://www.openstreetmap.org>OpenStreetMap</a>',
+              })
+            "
+          />
+        </q-item-section>
+      </q-item>
     </q-list>
   </div>
 </template>
@@ -197,7 +216,9 @@ export default defineComponent({
           this.isLoading = false;
         });
 
-        if (!results.bbox) {
+        if (results.features.length == 0) {
+          // no results
+        } else if (!results.bbox) {
           console.error('search results missing bounding box');
         } else if (results.bbox.length != 4) {
           console.error('unexpected bbox dimensions');


### PR DESCRIPTION
Previously it wasn't really clear if the search completed.

<img width="503" alt="Screenshot 2024-01-12 at 10 47 51" src="https://github.com/headwaymaps/headway/assets/217057/c2e137dd-1005-45e7-b444-eff53d0c5806">
