### PR TITLE
[ui] Show "2 minutes ago" rather than "in -120 seconds"

### DIFF
--- a/services/frontend/www-app/src/components/MultiModalListItem.vue
+++ b/services/frontend/www-app/src/components/MultiModalListItem.vue
@@ -15,17 +15,10 @@
   <q-item-label caption v-if="active">
     {{ trip.formattedFootDistance() }}
   </q-item-label>
-  <div v-if="trip.firstTransitLeg?.realTime">
+  <div v-if="formattedRealTimeUntilStart() !== undefined">
     <q-icon name="rss_feed" style="margin-right: 4px" />
     <span class="real-time-departure-time">
-      {{
-        $t('departs_$timeDuration_from_now', {
-          timeDuration: formatDuration(
-            (trip.firstTransitLeg!.startTime - nowTime) / 1000,
-            'shortform'
-          ),
-        })
-      }}&nbsp;
+      {{ formattedRealTimeUntilStart() }}&nbsp;
     </span>
     <span class="real-time-departure-location">
       {{
@@ -58,6 +51,7 @@
 import Itinerary from 'src/models/Itinerary';
 import { defineComponent, PropType } from 'vue';
 import { formatDuration } from 'src/utils/format';
+import { i18n } from 'src/i18n/lang';
 
 export default defineComponent({
   name: 'MultiModalListItem',
@@ -83,7 +77,22 @@ export default defineComponent({
     return { nowTime: Date.now() };
   },
   methods: {
-    formatDuration,
+    formattedRealTimeUntilStart(): string | undefined {
+      let startTime = this.trip.firstTransitLeg?.startTime;
+      if (!startTime) {
+        return undefined;
+      }
+      let timeUntilStart = startTime - this.nowTime;
+      if (timeUntilStart < 0) {
+        return i18n.global.t('departs_$timeDuration_since_now', {
+          timeDuration: formatDuration(-timeUntilStart / 1000),
+        });
+      } else {
+        return i18n.global.t('departs_$timeDuration_from_now', {
+          timeDuration: formatDuration(timeUntilStart / 1000),
+        });
+      }
+    },
   },
 });
 </script>

--- a/services/frontend/www-app/src/i18n/en-US/index.ts
+++ b/services/frontend/www-app/src/i18n/en-US/index.ts
@@ -60,6 +60,7 @@ export default {
   trip_search_depart_now: 'Leave now',
   trip_search_transit_with_bike: '🚲 Transit with a bike',
   departs_$timeDuration_from_now: 'in {timeDuration}',
+  departs_$timeDuration_since_now: '{timeDuration} ago',
   departs_at_$location: 'from {location}',
   transit_timeline_wait_for_transit_$timeDuration: 'wait up to {timeDuration}',
   edit_poi_button: 'Edit Details',


### PR DESCRIPTION
*before* if a departure occurred in the past, you'd see
<img width="375" alt="Screenshot 2024-01-22 at 12 16 07" src="https://github.com/headwaymaps/headway/assets/217057/e42b035d-abd8-4d2e-9d78-cd28db1e5689">

*now* you'll see something like:
<img width="371" alt="Screenshot 2024-01-22 at 12 14 53" src="https://github.com/headwaymaps/headway/assets/217057/3abed7b9-3f7a-4aec-a2f6-109ff520a5d6">
