### PR TITLE
[ui] mark transfers / legs

### DIFF
--- a/services/frontend/www-app/src/components/BaseMap.vue
+++ b/services/frontend/www-app/src/components/BaseMap.vue
@@ -157,6 +157,7 @@ export interface BaseMapInterface {
   fitBounds: (bounds: LngLatBoundsLike, options?: FitBoundsOptions) => void;
   setCursor: (key: string) => void;
   pushMarker: (key: string, marker: Marker) => void;
+  hasMarker(key: string): boolean;
   removeMarker: (key: string) => void;
   removeAllMarkers: () => void;
   removeMarkersExcept: (keys: string[]) => void;
@@ -242,6 +243,9 @@ export default defineComponent({
       }
       this.markers.set(key, marker);
       this.ensureMapLoaded((map) => marker.addTo(map));
+    },
+    hasMarker(key: string): boolean {
+      return this.markers.has(key);
     },
     removeMarker(key: string): boolean {
       let marker = this.markers.get(key);
@@ -456,6 +460,7 @@ export default defineComponent({
       flyTo: this.flyTo,
       fitBounds: this.fitBounds,
       pushMarker: this.pushMarker,
+      hasMarker: this.hasMarker,
       removeMarker: this.removeMarker,
       removeAllMarkers: this.removeAllMarkers,
       removeMarkersExcept: this.removeMarkersExcept,

--- a/services/frontend/www-app/src/models/Itinerary.ts
+++ b/services/frontend/www-app/src/models/Itinerary.ts
@@ -287,6 +287,11 @@ export class ItineraryLeg {
     };
   }
 
+  start(): LngLat {
+    const coordinates = this.geometry().coordinates;
+    return new LngLat(coordinates[0][0], coordinates[0][1]);
+  }
+
   paintStyle(active: boolean): LineLayerSpecification['paint'] {
     if (active) {
       if (this.mode == OTPMode.Walk || this.mode == OTPMode.Bicycle) {

--- a/services/frontend/www-app/src/models/Route.ts
+++ b/services/frontend/www-app/src/models/Route.ts
@@ -87,6 +87,10 @@ export default class Route implements Trip {
             coordinates: points,
           };
         },
+        start(): LngLat {
+          const coordinates = this.geometry().coordinates;
+          return new LngLat(coordinates[0][0], coordinates[0][1]);
+        },
         paintStyle(active: boolean): LineLayerSpecification['paint'] {
           if (active) {
             const firstManeuver = vLeg.maneuvers[0];

--- a/services/frontend/www-app/src/models/Trip.ts
+++ b/services/frontend/www-app/src/models/Trip.ts
@@ -14,6 +14,7 @@ export default interface Trip {
 
 export interface TripLeg {
   geometry(): GeoJSON.LineString;
+  start(): LngLat;
   paintStyle(active: boolean): LineLayerSpecification['paint'];
 }
 

--- a/services/frontend/www-app/src/models/TripLayerId.ts
+++ b/services/frontend/www-app/src/models/TripLayerId.ts
@@ -1,24 +1,41 @@
+enum LegPart {
+  START = 'start',
+  MIDDLE = 'middle',
+}
+
 export default class TripLayerId {
   tripIdx: number;
   legIdx: number;
   selected: boolean;
+  legPart: LegPart;
 
-  constructor(tripIdx: number, legIdx: number, selected: boolean) {
+  constructor(
+    tripIdx: number,
+    legIdx: number,
+    selected: boolean,
+    legPart: LegPart
+  ) {
     this.tripIdx = tripIdx;
     this.legIdx = legIdx;
     this.selected = selected;
+    this.legPart = legPart;
   }
 
-  static selected(tripIdx: number, legIdx: number): TripLayerId {
-    return new TripLayerId(tripIdx, legIdx, true);
+  static selectedLeg(tripIdx: number, legIdx: number): TripLayerId {
+    return new TripLayerId(tripIdx, legIdx, true, LegPart.MIDDLE);
   }
 
-  static unselected(tripIdx: number, legIdx: number): TripLayerId {
-    return new TripLayerId(tripIdx, legIdx, false);
+  static unselectedLeg(tripIdx: number, legIdx: number): TripLayerId {
+    return new TripLayerId(tripIdx, legIdx, false, LegPart.MIDDLE);
+  }
+
+  static legStart(tripIdx: number, legIdx: number): TripLayerId {
+    // Note: no difference between selected and unselected
+    return new TripLayerId(tripIdx, legIdx, true, LegPart.START);
   }
 
   public toString(): string {
     const selectionState = this.selected ? 'selected' : 'unselected';
-    return `trip_${this.tripIdx}_leg_${this.legIdx}_${selectionState}`;
+    return `trip_${this.tripIdx}_leg_${this.legIdx}_${selectionState}_${this.legPart}`;
   }
 }

--- a/services/frontend/www-app/src/pages/AlternatesPage.vue
+++ b/services/frontend/www-app/src/pages/AlternatesPage.vue
@@ -91,6 +91,7 @@ export default defineComponent({
   },
   data(): {
     trips: Trip[];
+    tripMarkers: string[];
     error?: TripFetchError;
     activeTrip?: Trip;
     isLoading: boolean;
@@ -100,6 +101,7 @@ export default defineComponent({
   } {
     return {
       trips: [],
+      tripMarkers: [],
       error: undefined,
       activeTrip: undefined,
       isLoading: false,
@@ -265,22 +267,29 @@ export default defineComponent({
         for (let legIdx = 0; legIdx < trip.legs.length; legIdx++) {
           const leg = trip.legs[legIdx];
           if (tripIdx == selectedIdx) {
-            if (map.hasLayer(TripLayerId.unselected(tripIdx, legIdx))) {
-              map.removeLayer(TripLayerId.unselected(tripIdx, legIdx));
+            if (map.hasLayer(TripLayerId.unselectedLeg(tripIdx, legIdx))) {
+              map.removeLayer(TripLayerId.unselectedLeg(tripIdx, legIdx));
             }
             continue;
           }
 
-          if (map.hasLayer(TripLayerId.selected(tripIdx, legIdx))) {
-            map.removeLayer(TripLayerId.selected(tripIdx, legIdx));
+          if (map.hasLayer(TripLayerId.selectedLeg(tripIdx, legIdx))) {
+            map.removeLayer(TripLayerId.selectedLeg(tripIdx, legIdx));
           }
 
-          if (map.hasLayer(TripLayerId.unselected(tripIdx, legIdx))) {
+          if (map.hasLayer(TripLayerId.unselectedLeg(tripIdx, legIdx))) {
             continue;
           }
 
-          let layerId = TripLayerId.unselected(tripIdx, legIdx);
+          let layerId = TripLayerId.unselectedLeg(tripIdx, legIdx);
           map.pushTripLayer(layerId, leg.geometry(), leg.paintStyle(false));
+          if (legIdx > 0) {
+            let transferLayerId = TripLayerId.legStart(tripIdx, legIdx);
+            map.pushMarker(
+              transferLayerId.toString(),
+              Markers.transfer().setLngLat(leg.start())
+            );
+          }
           map.on('mouseover', layerId.toString(), () => {
             map.setCursor('pointer');
           });
@@ -297,9 +306,9 @@ export default defineComponent({
       const selectedTrip = trips[selectedIdx];
       for (let legIdx = 0; legIdx < selectedTrip.legs.length; legIdx++) {
         const leg = selectedTrip.legs[legIdx];
-        if (!map.hasLayer(TripLayerId.selected(selectedIdx, legIdx))) {
+        if (!map.hasLayer(TripLayerId.selectedLeg(selectedIdx, legIdx))) {
           map.pushTripLayer(
-            TripLayerId.selected(selectedIdx, legIdx),
+            TripLayerId.selectedLeg(selectedIdx, legIdx),
             leg.geometry(),
             leg.paintStyle(true)
           );

--- a/services/frontend/www-app/src/utils/Markers.ts
+++ b/services/frontend/www-app/src/utils/Markers.ts
@@ -11,6 +11,12 @@ export default {
     marker.getElement().classList.add('cursor-pointer');
     return marker;
   },
+  transfer: (): Marker => {
+    const element = document.createElement('div');
+    element.innerHTML =
+      '<svg display="block" height="15" width="15"><circle cx="8" cy="8" r="5" stroke="#888" stroke-width="2" fill="white" /></svg>';
+    return new Marker({ element });
+  },
   tripStart: (): Marker => {
     const element = document.createElement('div');
     element.innerHTML =


### PR DESCRIPTION
Otherwise it can be hard to see precisely where you switch buses or start walking.

The former is a bigger problem than the latter, but I think it's worth showing for pedestrian leg start/ends as well for design consistency with the transit timeline "nodes" (in the left panel/bottom card).

**before:**
<img width="959" alt="Screenshot 2024-01-23 at 16 11 37" src="https://github.com/headwaymaps/headway/assets/217057/a099c6be-ab69-462f-a52b-ffa89fae9755">

**after:**
![image](https://github.com/headwaymaps/headway/assets/217057/685c9a82-6dd7-4bad-8ccf-74c8fcef1ea8)

**annotated (in case you missed it 😉):**
![image](https://github.com/headwaymaps/headway/assets/217057/bdf77f67-10a1-4740-86f4-7814862cf1b0)
