### PR TITLE
[ui] add missing padding to "edit on osm" link

### DIFF
--- a/services/frontend/www-app/src/components/PlaceCard.vue
+++ b/services/frontend/www-app/src/components/PlaceCard.vue
@@ -61,7 +61,7 @@
           $t('edit_poi_button')
         }}</q-btn>
       </div>
-      <div v-if="showEditPanel" style="margin-top: 8px">
+      <div v-if="showEditPanel" style="margin-top: 8px; padding: 16px">
         <p>{{ $t('edit_poi_about_osm') }}</p>
         <div style="text-align: center">
           <q-btn


### PR DESCRIPTION
Just a little css tweak
**before**
<img width="530" alt="Screenshot 2024-01-25 at 19 11 50" src="https://github.com/headwaymaps/headway/assets/217057/844f4dde-a759-4552-9f52-3c30dbac8b4c">
**after**
<img width="549" alt="Screenshot 2024-01-25 at 19 11 57" src="https://github.com/headwaymaps/headway/assets/217057/839fa828-13ed-449f-8cb9-6c1f7229ad4b">
