### PR TITLE
[www] fix 404 on spritesheet

### DIFF
--- a/services/frontend/nginx.conf.template
+++ b/services/frontend/nginx.conf.template
@@ -21,11 +21,11 @@ http {
     resolver ${HEADWAY_RESOLVER};
     listen ${HEADWAY_HTTP_PORT} default_server;
 
-    location /pelias/  {
+    location ^~ /pelias/  {
       proxy_pass      ${HEADWAY_PELIAS_URL}/;
     }
 
-    location /transitmux/ {
+    location ^~ /transitmux/ {
       set $enable_transit_routing ${HEADWAY_ENABLE_TRANSIT_ROUTING};
       if ($enable_transit_routing != 1) {
         return 404;
@@ -33,22 +33,22 @@ http {
       proxy_pass      ${HEADWAY_TRANSITMUX_URL}/;
     }
 
-    location /valhalla/  {
+    location ^~ /valhalla/  {
       proxy_pass      ${HEADWAY_VALHALLA_URL}/;
     }
 
-    location /tileserver/  {
+    location ^~ /tileserver/  {
       expires 1h;
       proxy_pass       ${HEADWAY_TILESERVER_URL}/;
     }
 
-    location /static/  {
+    location ^~ /static/  {
       alias ${HEADWAY_SHARED_VOL}/;
       expires 5m;
       add_header Cache-Control "public";
     }
 
-    location / {
+    location ^~ / {
       try_files ${ESC}uri /index.html;
       # From https://quasar.dev/quasar-cli-vite/developing-spa/deploying/
       #


### PR DESCRIPTION
I broke this in 1f567b7

From https://docs.nginx.com/nginx/admin-guide/web-server/web-server/

== NGINX Location Priority ==

1. Test the URI against all prefix strings.
2. The = (equals sign) modifier defines an exact match of the URI and a prefix string. If the exact match is found, the search stops.
3. If the ^~ (caret-tilde) modifier prepends the longest matching prefix string, the regular expressions are not checked.
4. Store the longest matching prefix string.
5. Test the URI against regular expressions.
6. Stop processing when the first matching regular expression is found and use the corresponding location.
7. If no regular expression matches, use the location corresponding to the stored prefix string.

==

The broken request: /tileserver/styles/basic/sprite@2x.png

Before 1f567b7, we matched the correct Location via rule 7, with the
`/tileserver` prefix stored in step 4.

After 1f567b7, it matched the wrong Location via rule 5.

By introducing the ^~, we match the right Location via rule 3.
