### PR TITLE
[www] Show compass on supported platforms

### DIFF
--- a/services/frontend/www-app/src/components/BaseMap.vue
+++ b/services/frontend/www-app/src/components/BaseMap.vue
@@ -3,6 +3,19 @@
 </template>
 
 <style lang="scss">
+.headway-device-orientation-indicator {
+  position: relative;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.headway-device-orientation-indicator svg {
+  position: relative;
+  top: 3px;
+  left: -33px;
+  transition: transform 0.2s ease;
+}
+
 .headway-ctrl-scale {
   display: flex;
   flex-direction: row;
@@ -92,6 +105,7 @@ import Place, { PlaceId } from 'src/models/Place';
 import TripLayerId from 'src/models/TripLayerId';
 import env from 'src/utils/env';
 import WrapperControl from 'src/ui/WrapperControl';
+import LocationControl from 'src/ui/LocationControl';
 
 export var map: maplibregl.Map | null = null;
 const mapContainerId = 'map';
@@ -480,7 +494,7 @@ export default defineComponent({
     // controls in the bottom right, this the compact version is taking up a more contentious resource.
     const attributionControl = new AttributionControl({ compact: false });
     const scaleControl = new ScaleControl({ maxWidth: 120 });
-    const geolocate = new maplibregl.GeolocateControl({
+    const geolocate = new LocationControl({
       positionOptions: { enableHighAccuracy: true },
       showAccuracyCircle: true,
       showUserLocation: true,
@@ -497,7 +511,7 @@ export default defineComponent({
 
     map.addControl(attributionControl, 'bottom-right');
 
-    let wrapperControl = new WrapperControl();
+    const wrapperControl = new WrapperControl();
     wrapperControl.pushChild(scaleControl);
     wrapperControl.pushChild(geolocate);
     map.addControl(wrapperControl, 'bottom-right');

--- a/services/frontend/www-app/src/ui/LocationControl.test.ts
+++ b/services/frontend/www-app/src/ui/LocationControl.test.ts
@@ -1,0 +1,17 @@
+import LocationControl from './LocationControl';
+
+describe('LocationControl', () => {
+  describe('nearestDelta', () => {
+    it('should calculate the shortest distance between two angles', () => {
+      expect(LocationControl.nearestDelta(0, 90)).toBe(90);
+      expect(LocationControl.nearestDelta(90, 0)).toBe(-90);
+      expect(LocationControl.nearestDelta(180, 270)).toBe(90);
+      expect(LocationControl.nearestDelta(270, 180)).toBe(-90);
+      expect(LocationControl.nearestDelta(0, 360)).toBe(0);
+      expect(LocationControl.nearestDelta(360, 0)).toBe(-0);
+      expect(LocationControl.nearestDelta(359, 1)).toBe(2);
+      expect(LocationControl.nearestDelta(1, 359)).toBe(-2);
+      expect(LocationControl.nearestDelta(5 + 360 * 2, 6)).toBe(1);
+    });
+  });
+});

--- a/services/frontend/www-app/src/ui/LocationControl.ts
+++ b/services/frontend/www-app/src/ui/LocationControl.ts
@@ -1,0 +1,107 @@
+import {
+  Map,
+  GeolocateControl,
+  GeolocateControlOptions,
+  Evented,
+  IControl,
+} from 'maplibre-gl';
+import env from 'src/utils/env';
+
+/**
+ * A wrapper for maplibre-gl's GeolocateControl that adds a compass to the user's location dot,
+ * showing which way the user is facing. The compass is only supported on some
+ * platforms - notably desktop devices likely do not have a compass, but the location dot will
+ * still be shown.
+ */
+export default class LocationControl extends Evented implements IControl {
+  geolocateControl: GeolocateControl;
+  compassEl: HTMLElement;
+  svgEl: HTMLElement;
+  isAddedToDOM = false;
+  currentRotation = 0;
+
+  constructor(options: GeolocateControlOptions) {
+    super();
+    this.geolocateControl = new GeolocateControl(options);
+
+    const compassEl = document.createElement('div');
+    compassEl.className = 'headway-device-orientation-indicator';
+
+    const svg = `<svg width="80" height="80" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <radialGradient id="strokeGradient" cx="50%" cy="50%" r="50%" fx="50%" fy="50%">
+        <stop offset="50%" stop-color="#1da1f2" stop-opacity="0.7" /> <!-- inner -->
+        <stop offset="100%" stop-color="#1da1f2" stop-opacity="0" /> <!-- outer-->
+      </radialGradient>
+    </defs>
+    <circle r="40" cx="40" cy="40"
+      fill="none"
+      stroke="url(#strokeGradient)"
+      stroke-width="70"
+      stroke-dasharray="30 300" />
+    </svg>`;
+    const svgEl = new DOMParser().parseFromString(
+      svg,
+      'image/svg+xml',
+    ).documentElement;
+
+    this.svgEl = svgEl;
+    compassEl.append(svgEl);
+    this.compassEl = compassEl;
+  }
+
+  /** {@inheritDoc IControl.onAdd} */
+  onAdd(map: Map) {
+    env.deviceOrientation.subscribe((compassHeading) => {
+      this.orientationDidUpdate(compassHeading);
+    });
+    const geolocateControlEl = this.geolocateControl.onAdd(map);
+
+    geolocateControlEl.addEventListener('click', () => {
+      env.deviceOrientation.startWatching();
+    });
+
+    return geolocateControlEl;
+  }
+
+  /** {@inheritDoc IControl.onRemove} */
+  onRemove() {
+    return this.geolocateControl.onRemove();
+  }
+
+  orientationDidUpdate(compassHeading: number) {
+    if (this.geolocateControl._dotElement === undefined) {
+      return;
+    }
+
+    if (!this.isAddedToDOM) {
+      this.geolocateControl._dotElement.appendChild(this.compassEl);
+      this.isAddedToDOM = true;
+    }
+
+    // Align our design asset to correspond with the compass offset
+    const graphicOffset = 180.0 + 69;
+
+    // Adjust the target angle for a smooth transition
+    const targetAngle = (graphicOffset + compassHeading) % 360;
+
+    // Avoid a janky animation when wrapping around 360->0
+    const delta = LocationControl.nearestDelta(
+      this.currentRotation,
+      targetAngle,
+    );
+    const finalAngle = this.currentRotation + delta;
+    this.svgEl.style.transform = `rotate(${finalAngle}deg)`;
+    this.currentRotation = finalAngle;
+  }
+
+  // calculate the shortest distance between two angles
+  static nearestDelta(from: number, to: number): number {
+    const distance = (to - from) % 360;
+    return distance > 180
+      ? distance - 360
+      : distance < -180
+        ? distance + 360
+        : distance;
+  }
+}

--- a/services/frontend/www-app/src/utils/DeviceOrientationPolyfill.ts
+++ b/services/frontend/www-app/src/utils/DeviceOrientationPolyfill.ts
@@ -1,0 +1,161 @@
+import { throttle } from 'lodash';
+import { Platform } from 'quasar';
+
+// Type definitions for DeviceOrientationEvent, which is not
+// currently defined in the typescript standard library.
+type PermissionStatus = 'granted' | 'denied' | 'prompt';
+
+type State =
+  | 'init'
+  | 'requestingPermission'
+  | 'permissionDenied'
+  | 'unsupported'
+  | 'watching';
+
+export default class DeviceOrientationPolyfill {
+  private mostRecentHeading: number | null = null;
+  private state: State = 'init';
+  private subscribers: ((orientation: number) => void)[] = [];
+
+  /**
+   * Currently only Safari supports DeviceOrientationEvent.requestPermission. Other platforms allow
+   * access to this information without explicit user permission.
+   *
+   * On iOS, this request must occur in response to a button press or else it
+   * will be automatically denied without exposing any UI to the user.
+   */
+  requestPermission(): Promise<PermissionStatus> {
+    this.state = 'requestingPermission';
+    if (
+      // @ts-expect-error: DeviceOrientationEvent.requestPermission is currently only defined in webkit
+      typeof DeviceOrientationEvent.requestPermission === 'function'
+    ) {
+      // console.log('Calling actual DeviceOrientationEvent.requestPermission()');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (DeviceOrientationEvent as any).requestPermission();
+    } else {
+      // console.log('Assuming permissions, since DeviceOrientationEvent.requestPermission does not exist');
+      return Promise.resolve('granted');
+    }
+  }
+
+  startWatching(): void {
+    this.requestPermission().then((status) => {
+      console.assert(
+        this.state == 'requestingPermission',
+        `unexpected state: ${this.state}`,
+      );
+      if (status === 'granted') {
+        this.state = 'watching';
+
+        // it's useful to be able to test this on desktop
+        const testing = false;
+        if (testing && Platform.is.desktop) {
+          // console.log('fake device orientation for testing on desktop');
+          setInterval(() => {
+            // start north and turn clockwise
+            const orientation =
+              ((this.mostRecentHeading ?? -45.0) + 45.0) % 360.0;
+            this.onDeviceOrientation({
+              alpha: orientation,
+              absolute: true,
+            } as DeviceOrientationEvent);
+          }, 200);
+        } else {
+          // On iOS, listening to 'deviceorientation' produces angles with the webkitCompassHeading.
+          // On Android it only produces angles with the non-absolute alphas, which are worthless to us,
+          // so we listen to 'deviceorientationabsolute' instead.
+          if (Platform.is.ios) {
+            window.addEventListener('deviceorientation', (e) =>
+              this.onDeviceOrientation(e),
+            );
+          } else {
+            window.addEventListener('deviceorientationabsolute', (e) =>
+              this.onDeviceOrientation(e as DeviceOrientationEvent),
+            );
+          }
+        }
+      } else {
+        console.assert(status === 'denied', `unexpected status: ${status}`);
+        this.state = 'permissionDenied';
+      }
+    });
+  }
+
+  stopWatching(): void {
+    console.assert(
+      this.state == 'unsupported',
+      `unexpected state: ${this.state}`,
+    );
+    window.removeEventListener('deviceorientation', this.onDeviceOrientation);
+    window.removeEventListener(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      'deviceorientationabsolute' as any,
+      this.onDeviceOrientation,
+    );
+  }
+
+  /**
+   * Get notified when the compass heading changes.
+   * 0 is north, 90 is east, 180 is south, 270 is west.
+   *
+   * Callback is throttled and only called when the change is significant.
+   *
+   * @param callback - called when the compass heading changes significantly
+   */
+  subscribe(callback: (compassHeading: number) => void): void {
+    this.subscribers.push(callback);
+  }
+
+  // Maybe throttle less aggressively, and instead ensure it's "significant" change.
+  private onDeviceOrientation = throttle(
+    (event: DeviceOrientationEvent): void => {
+      console.assert(
+        this.state == 'watching',
+        `unexpected state: ${this.state}`,
+      );
+      const significantChange = 1.0;
+
+      // On iOS: listening to `deviceorientation` triggers events with
+      // `webkitCompassHeading` which is what we ultimately need.
+      // On Android: `deviceorientation` triggers events with an `alpha`
+      // relative to whatever direction the user was initially facing.  This is
+      // not useful to us, so we listen to `deviceorientationabsolute` instead.
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      let newHeading: number | null = null;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if (typeof (event as any).webkitCompassHeading === 'number') {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        newHeading = (event as any).webkitCompassHeading;
+      } else if (typeof event.alpha === 'number') {
+        if (event.absolute) {
+          // convert alpha to compass direction
+          newHeading = (360 - event.alpha) % 360;
+        } else {
+          // Not interested in relative angles.
+          return;
+        }
+      }
+
+      if (newHeading == null) {
+        console.assert(false, 'DeviceOrientationEvent missing angle');
+        return;
+      }
+
+      if (
+        this.mostRecentHeading &&
+        Math.abs(newHeading - this.mostRecentHeading) < significantChange
+      ) {
+        // console.log('ignoring insignificant change');
+        return;
+      }
+
+      this.mostRecentHeading = newHeading;
+      for (const subscriber of this.subscribers) {
+        subscriber(this.mostRecentHeading);
+      }
+    },
+    100,
+  );
+}

--- a/services/frontend/www-app/src/utils/GeolocationPolyfill.ts
+++ b/services/frontend/www-app/src/utils/GeolocationPolyfill.ts
@@ -1,4 +1,5 @@
 import { Platform } from 'quasar';
+import LocationControl from 'src/ui/LocationControl';
 
 export default class GeolocationPolyfill {
   mostRecentPosition: GeolocationPosition | undefined;
@@ -55,21 +56,22 @@ export default class GeolocationPolyfill {
     }
   }
 
-  register(geolocationControl: maplibregl.GeolocateControl): void {
+  register(geolocationControl: LocationControl): void {
     console.assert(
       !this.isRegistered,
       'GeolocationPolyfill has already been registered.',
     );
 
-    geolocationControl.on('geolocate', (position) => {
+    geolocationControl.on('geolocate', (position: GeolocationPosition) => {
       console.debug('updating mostRecentPosition', position);
       this.mostRecentPosition = position;
     });
-    geolocationControl.on('trackuserlocationstart', (e) => {
+    geolocationControl.on('trackuserlocationstart', (e: unknown) => {
       console.debug('starting user location watch', e);
       this.isWatching = true;
     });
-    geolocationControl.on('trackuserlocationend', (e) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    geolocationControl.on('trackuserlocationend', (e: any) => {
       console.debug('ending user location watch', e);
       switch (e.target._watchState) {
         case 'BACKGROUND': {

--- a/services/frontend/www-app/src/utils/env.ts
+++ b/services/frontend/www-app/src/utils/env.ts
@@ -1,6 +1,7 @@
 import GeolocationPolyfill from './GeolocationPolyfill';
-
+import DeviceOrientationPolyfill from './DeviceOrientationPolyfill';
 // One singleton to rule them all
 export default {
   geolocation: new GeolocationPolyfill(),
+  deviceOrientation: new DeviceOrientationPolyfill(),
 };


### PR DESCRIPTION
Some mobile browsers support reporting device orientation. On those
platforms we now show a visible compass direction whenever the
geolocation dot is shown to help orient the user.
