### PR TITLE
Fix: device orientation indicator should rotate with map

### DIFF
--- a/services/frontend/www-app/.eslintrc.js
+++ b/services/frontend/www-app/.eslintrc.js
@@ -82,6 +82,10 @@ module.exports = {
     // does not work with type definitions
     'no-unused-vars': 'off',
 
+    // Any is "bad", and you should feel bad if you use it, but it sure is convenient sometimes
+    '@typescript-eslint/no-explicit-any':
+      process.env.NODE_ENV === 'production' ? 'error' : 'warn',
+
     // allow debugger during development only
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
   },

--- a/services/frontend/www-app/package.json
+++ b/services/frontend/www-app/package.json
@@ -6,7 +6,7 @@
   "author": "Ellen Poe <ellen@ellenhp.me>",
   "private": true,
   "scripts": {
-    "lint": "eslint --ext .js,.ts,.vue ./",
+    "lint": "NODE_ENV=production eslint --ext .js,.ts,.vue ./",
     "format-check": "prettier --check \"**/*.{js,ts,vue,scss,html,md,json}\" --ignore-path .gitignore",
     "fmt": "yarn format",
     "format": "prettier --write \"**/*.{js,ts,vue,scss,html,md,json}\" --ignore-path .gitignore",

--- a/services/frontend/www-app/src/components/BaseMap.vue
+++ b/services/frontend/www-app/src/components/BaseMap.vue
@@ -3,16 +3,9 @@
 </template>
 
 <style lang="scss">
-.headway-device-orientation-indicator {
-  position: relative;
-  top: 50%;
-  transform: translateY(-50%);
-}
-
 .headway-device-orientation-indicator svg {
   position: relative;
   top: 3px;
-  left: -33px;
   transition: transform 0.2s ease;
 }
 

--- a/services/frontend/www-app/src/ui/LocationControl.ts
+++ b/services/frontend/www-app/src/ui/LocationControl.ts
@@ -4,6 +4,8 @@ import {
   GeolocateControlOptions,
   Evented,
   IControl,
+  Marker,
+  LngLat,
 } from 'maplibre-gl';
 import env from 'src/utils/env';
 
@@ -17,8 +19,12 @@ export default class LocationControl extends Evented implements IControl {
   geolocateControl: GeolocateControl;
   compassEl: HTMLElement;
   svgEl: HTMLElement;
-  isAddedToDOM = false;
   currentRotation = 0;
+  compassMarker: Marker;
+
+  mostRecentPosition?: LngLat;
+  mostRecentCompassHeading?: number;
+  map?: Map;
 
   constructor(options: GeolocateControlOptions) {
     super();
@@ -26,36 +32,28 @@ export default class LocationControl extends Evented implements IControl {
 
     const compassEl = document.createElement('div');
     compassEl.className = 'headway-device-orientation-indicator';
-
-    const svg = `<svg width="80" height="80" xmlns="http://www.w3.org/2000/svg">
-    <defs>
-      <radialGradient id="strokeGradient" cx="50%" cy="50%" r="50%" fx="50%" fy="50%">
-        <stop offset="50%" stop-color="#1da1f2" stop-opacity="0.7" /> <!-- inner -->
-        <stop offset="100%" stop-color="#1da1f2" stop-opacity="0" /> <!-- outer-->
-      </radialGradient>
-    </defs>
-    <circle r="40" cx="40" cy="40"
-      fill="none"
-      stroke="url(#strokeGradient)"
-      stroke-width="70"
-      stroke-dasharray="30 300" />
-    </svg>`;
-    const svgEl = new DOMParser().parseFromString(
-      svg,
-      'image/svg+xml',
-    ).documentElement;
-
+    const svgEl = buildSvgElement(40);
     this.svgEl = svgEl;
     compassEl.append(svgEl);
     this.compassEl = compassEl;
+
+    this.compassMarker = new Marker({
+      element: compassEl,
+      pitchAlignment: 'map',
+      rotationAlignment: 'map',
+    });
   }
 
   /** {@inheritDoc IControl.onAdd} */
   onAdd(map: Map) {
-    env.deviceOrientation.subscribe((compassHeading) => {
-      this.orientationDidUpdate(compassHeading);
-    });
+    this.map = map;
+    env.deviceOrientation.subscribe(this._updateMarkerRotation.bind(this));
+
     const geolocateControlEl = this.geolocateControl.onAdd(map);
+    this.geolocateControl.on(
+      'geolocate',
+      this._updateMarkerPosition.bind(this),
+    );
 
     geolocateControlEl.addEventListener('click', () => {
       env.deviceOrientation.startWatching();
@@ -66,24 +64,49 @@ export default class LocationControl extends Evented implements IControl {
 
   /** {@inheritDoc IControl.onRemove} */
   onRemove() {
+    this.map = undefined;
+    this.geolocateControl.off('geolocate', this._updateMarkerPosition);
+    this.geolocateControl.off('geolocate', this._updateMarkerPosition);
     return this.geolocateControl.onRemove();
   }
 
-  orientationDidUpdate(compassHeading: number) {
-    if (this.geolocateControl._dotElement === undefined) {
+  _updateMarkerPosition(position?: GeolocationPosition | null): void {
+    if (position) {
+      this.mostRecentPosition = new LngLat(
+        position.coords.longitude,
+        position.coords.latitude,
+      );
+    } else {
+      console.assert(false, 'position should not be null');
+      this.mostRecentPosition = undefined;
+    }
+    this._updateMarker();
+  }
+
+  _updateMarkerRotation(compassHeading: number): void {
+    this.mostRecentCompassHeading = compassHeading;
+    this._updateMarker();
+  }
+
+  _updateMarker() {
+    if (
+      this.mostRecentPosition === undefined ||
+      this.mostRecentCompassHeading == undefined ||
+      this.map === undefined
+    ) {
+      this.compassMarker.remove();
       return;
     }
-
-    if (!this.isAddedToDOM) {
-      this.geolocateControl._dotElement.appendChild(this.compassEl);
-      this.isAddedToDOM = true;
+    this.compassMarker.setLngLat(this.mostRecentPosition);
+    if (this.compassMarker._map !== this.map) {
+      this.compassMarker.addTo(this.map);
     }
 
     // Align our design asset to correspond with the compass offset
-    const graphicOffset = 180.0 + 69;
+    const graphicOffset = 180.0 + 62;
 
     // Adjust the target angle for a smooth transition
-    const targetAngle = (graphicOffset + compassHeading) % 360;
+    const targetAngle = (graphicOffset + this.mostRecentCompassHeading) % 360;
 
     // Avoid a janky animation when wrapping around 360->0
     const delta = LocationControl.nearestDelta(
@@ -91,6 +114,8 @@ export default class LocationControl extends Evented implements IControl {
       targetAngle,
     );
     const finalAngle = this.currentRotation + delta;
+    // We use a CSS transform rather than Marker.rotation so that
+    // we can smooth it out with an animation.
     this.svgEl.style.transform = `rotate(${finalAngle}deg)`;
     this.currentRotation = finalAngle;
   }
@@ -104,4 +129,26 @@ export default class LocationControl extends Evented implements IControl {
         ? distance + 360
         : distance;
   }
+}
+
+function buildSvgElement(coneLength: number): HTMLElement {
+  const svgWidth = coneLength + 20;
+  const circleRadius = svgWidth / 2;
+
+  const svgText = `<svg width="${svgWidth}" height="${svgWidth}" xmlns="http://www.w3.org/2000/svg">
+   <defs>
+     <radialGradient id="strokeGradient" cx="50%" cy="50%" r="50%" fx="50%" fy="50%">
+       <stop offset="50%" stop-color="#1da1f2" stop-opacity="0.7" /> <!-- inner -->
+       <stop offset="100%" stop-color="#1da1f2" stop-opacity="0" /> <!-- outer-->
+     </radialGradient>
+   </defs>
+   <circle r="${circleRadius}" cx="${circleRadius}" cy="${circleRadius}"
+     fill="none"
+     stroke="url(#strokeGradient)"
+     stroke-width="${coneLength}"
+     stroke-dasharray="30 ${svgWidth * 4}" />
+   </svg>`;
+
+  return new DOMParser().parseFromString(svgText, 'image/svg+xml')
+    .documentElement;
 }

--- a/services/frontend/www-app/src/utils/DeviceOrientationPolyfill.ts
+++ b/services/frontend/www-app/src/utils/DeviceOrientationPolyfill.ts
@@ -49,18 +49,25 @@ export default class DeviceOrientationPolyfill {
         this.state = 'watching';
 
         // it's useful to be able to test this on desktop
-        const testing = false;
-        if (testing && Platform.is.desktop) {
+        const fakeOnDesktop = false;
+        if (fakeOnDesktop && Platform.is.desktop) {
           // console.log('fake device orientation for testing on desktop');
-          setInterval(() => {
+          // setInterval(() => {
+          setTimeout(() => {
             // start north and turn clockwise
-            const orientation =
-              ((this.mostRecentHeading ?? -45.0) + 45.0) % 360.0;
+            let alpha;
+            if (this.mostRecentHeading === null) {
+              alpha = 0;
+            } else {
+              alpha = (360 - this.mostRecentHeading - 45) % 360;
+            }
+
+            // console.log(`mostRecentHeading: ${this.mostRecentHeading}, alpha: ${alpha}`);
             this.onDeviceOrientation({
-              alpha: orientation,
+              alpha,
               absolute: true,
             } as DeviceOrientationEvent);
-          }, 200);
+          }, 1000);
         } else {
           // On iOS, listening to 'deviceorientation' produces angles with the webkitCompassHeading.
           // On Android it only produces angles with the non-absolute alphas, which are worthless to us,
@@ -151,6 +158,8 @@ export default class DeviceOrientationPolyfill {
         return;
       }
 
+      // console.log(`setting heading to: ${newHeading}`);
+      console.assert(newHeading >= 0);
       this.mostRecentHeading = newHeading;
       for (const subscriber of this.subscribers) {
         subscriber(this.mostRecentHeading);


### PR DESCRIPTION
Currently the device indication indicator is rendered assuming the map is always "north-on-top". If you rotate the map, the indicator will point in an inaccurate direction.