### PR TITLE
minimize confusion when location services are denied

### DIFF
--- a/services/frontend/www-app/.eslintrc.js
+++ b/services/frontend/www-app/.eslintrc.js
@@ -82,8 +82,10 @@ module.exports = {
     // does not work with type definitions
     'no-unused-vars': 'off',
 
-    // Any is "bad", and you should feel bad if you use it, but it sure is convenient sometimes
+    // Make development less painful
     '@typescript-eslint/no-explicit-any':
+      process.env.NODE_ENV === 'production' ? 'error' : 'warn',
+    '@typescript-eslint/no-unused-vars':
       process.env.NODE_ENV === 'production' ? 'error' : 'warn',
 
     // allow debugger during development only

--- a/services/frontend/www-app/src/components/BaseMap.vue
+++ b/services/frontend/www-app/src/components/BaseMap.vue
@@ -68,6 +68,37 @@
   animation: hideElement 0.2s forwards;
   animation-delay: 5s;
 }
+
+.headway-location-control-container {
+  position: relative;
+
+  .headway-location-disabled-banner {
+    position: absolute;
+    right: 0;
+    bottom: 24px;
+    width: 200px;
+    padding: 8px;
+    text-align: center;
+    background: rgba(255, 185, 185, 0.96);
+    // add shadow
+    box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.5);
+  }
+
+  .headway-location-control-click-interceptor {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+    pointer-events: all;
+    cursor: pointer;
+  }
+
+  &:has(button[disabled]) {
+    .headway-location-control-click-interceptor {
+      cursor: not-allowed;
+    }
+  }
+}
 </style>
 
 <script lang="ts">

--- a/services/frontend/www-app/src/i18n/en-US/index.ts
+++ b/services/frontend/www-app/src/i18n/en-US/index.ts
@@ -12,7 +12,8 @@ export default {
   try_driving_directions: 'Try driving directions instead?',
   where_to_question: 'Where to?',
   my_location: 'My Location',
-  could_not_get_gps_location: 'Could not get GPS location',
+  location_permission_denied_banner:
+    'Location permission was denied. Check your privacy settings.',
   dropped_pin: 'Dropped Pin',
   via_$place: 'via {place}',
   via$transit_route: 'via route {transitRoute}',

--- a/services/frontend/www-app/src/ui/LocationControl.ts
+++ b/services/frontend/www-app/src/ui/LocationControl.ts
@@ -55,6 +55,12 @@ export default class LocationControl extends Evented implements IControl {
       this._updateMarkerPosition.bind(this),
     );
 
+    // make sure the compass is hidden when the user stops tracking their location
+    this.geolocateControl.on(
+      'trackuserlocationend',
+      this._updateMarker.bind(this),
+    );
+
     geolocateControlEl.addEventListener('click', () => {
       env.deviceOrientation.startWatching();
     });
@@ -92,7 +98,8 @@ export default class LocationControl extends Evented implements IControl {
     if (
       this.mostRecentPosition === undefined ||
       this.mostRecentCompassHeading == undefined ||
-      this.map === undefined
+      this.map === undefined ||
+      this.geolocateControl._watchState == 'OFF'
     ) {
       this.compassMarker.remove();
       return;

--- a/services/frontend/www-app/src/utils/DeviceOrientationPolyfill.ts
+++ b/services/frontend/www-app/src/utils/DeviceOrientationPolyfill.ts
@@ -12,6 +12,8 @@ type State =
   | 'unsupported'
   | 'watching';
 
+let alreadySubscribedToFakeDeviceOrientation = false;
+
 export default class DeviceOrientationPolyfill {
   private mostRecentHeading: number | null = null;
   private state: State = 'init';
@@ -51,9 +53,13 @@ export default class DeviceOrientationPolyfill {
         // it's useful to be able to test this on desktop
         const fakeOnDesktop = false;
         if (fakeOnDesktop && Platform.is.desktop) {
+          if (alreadySubscribedToFakeDeviceOrientation) {
+            return;
+          }
+          alreadySubscribedToFakeDeviceOrientation = true;
+
           // console.log('fake device orientation for testing on desktop');
-          // setInterval(() => {
-          setTimeout(() => {
+          setInterval(() => {
             // start north and turn clockwise
             let alpha;
             if (this.mostRecentHeading === null) {


### PR DESCRIPTION
By default, if you deny location services (or have perhaps long ago denied location services), maplibre will render the geolocate button as disabled. But it's not really enough information to tell you whats going on.

Now, if a user tries to geolocate, but cannot, we show a dismissible explanation alongside the disabled button.

<img width="301" alt="Screenshot 2024-02-08 at 14 52 12" src="https://github.com/headwaymaps/headway/assets/217057/47ba0a8b-4165-497e-9047-916ef2ff738d">