### PR TITLE
Planetiler update

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: earthly/actions-setup@v1
         with:
           # pinning to `latest` requires using the GH API, which causes spurious rate limiting errors
-          version: "0.7.4"
+          version: "0.8.4"
       - uses: actions/checkout@v2
       - run: earthly --version
       - run: earthly -P +build --area=Bogota

--- a/Earthfile
+++ b/Earthfile
@@ -323,13 +323,7 @@ pelias-import:
 ##############################
 
 planetiler-build-mbtiles:
-    # The version tag is ignored when sha256 is specified, but I'm leaving it in as documentation
-    FROM ghcr.io/onthegomap/planetiler:0.5.0@sha256:79981c8af5330b384599e34d90b91a2c01b141be2c93a53244d14c49e2758c3c
-    # FIXME: The 0.6.0 release is failing on planet builds (reproduced on daylight maps v1.26 w/ building and admin)
-    # The 0.5.0 release builds it successfully. The 0.6.0 release can build a smaller map (e.g. Seattle) without error.
-    # Failing with:
-    #     java.util.concurrent.ExecutionException: java.io.UncheckedIOException: com.google.protobuf.InvalidProtocolBufferException: Protocol message contained an invalid tag (zero).
-    # FROM ghcr.io/onthegomap/planetiler:0.6.0@sha256:e937250696efc60f57e7952180645c6e4b1888d70fd61d04f1e182c5489eaa1c
+    FROM ghcr.io/onthegomap/planetiler:0.7.0
 
     RUN mkdir -p /data/sources
     RUN curl --no-progress-meter https://f000.backblazeb2.com/file/headway/sources.tar | tar -x --directory /data/sources
@@ -346,7 +340,18 @@ planetiler-build-mbtiles:
     #     "@/app/jib-classpath-file",
     #     "com.onthegomap.planetiler.Main"
     # ],
-    RUN --entrypoint -- --force --osm_path=/data/data.osm.pbf
+
+    COPY ./services/tilebuilder/percent-of-available-memory .
+
+    RUN --entrypoint -- \
+        -Xmx$(./percent-of-available-memory 75) \
+        `# return unused heap memory to the OS` \
+        -XX:MaxHeapFreeRatio=40 \
+        --osm_path=/data/data.osm.pbf \
+        # --bounds=planet \
+        `# Store temporary node locations at fixed positions in a memory-mapped file` \
+        --nodemap-type=array --storage=mmap \
+        --force
 
     SAVE ARTIFACT /data/output.mbtiles /output.mbtiles
 

--- a/Earthfile
+++ b/Earthfile
@@ -1,9 +1,9 @@
-VERSION --use-copy-link 0.6
-
+VERSION 0.8
 
 ##############################
 # OSM extract
 ##############################
+ARG --global is_planet_build = false
 
 build:
     # The name of <area>.osm.pbf if you've downloaded a custom extract, or the
@@ -343,15 +343,24 @@ planetiler-build-mbtiles:
 
     COPY ./services/tilebuilder/percent-of-available-memory .
 
-    RUN --entrypoint -- \
-        -Xmx$(./percent-of-available-memory 75) \
-        `# return unused heap memory to the OS` \
-        -XX:MaxHeapFreeRatio=40 \
-        --osm_path=/data/data.osm.pbf \
-        # --bounds=planet \
-        `# Store temporary node locations at fixed positions in a memory-mapped file` \
-        --nodemap-type=array --storage=mmap \
-        --force
+    IF [ "$is_planet_build" = "false" ]
+      RUN --entrypoint -- \
+          --osm_path=/data/data.osm.pbf \
+          --force
+    ELSE
+      RUN --entrypoint -- \
+          -Xmx$(./percent-of-available-memory 75) \
+          `# return unused heap memory to the OS` \
+          -XX:MaxHeapFreeRatio=40 \
+          --osm_path=/data/data.osm.pbf \
+
+          --bounds=planet \
+          `# Store temporary node locations at fixed positions in a memory-mapped file` \
+          --nodemap-type=array \
+          --storage=mmap \
+          --force
+    END
+
 
     SAVE ARTIFACT /data/output.mbtiles /output.mbtiles
 

--- a/bin/build
+++ b/bin/build
@@ -35,7 +35,13 @@ EARTHLY_ARGS=${@:1}
 
 source "${CONFIG_DIR}/env.sh"
 
-with_log earthly $EARTHLY_ARGS -P +build --area="$HEADWAY_AREA" --countries="$HEADWAY_COUNTRIES"
+if [ "$HEADWAY_COUNTRIES" = "ALL" ]; then
+    HEADWAY_IS_PLANET_BUILD=true
+else
+    HEADWAY_IS_PLANET_BUILD=false
+fi
+
+with_log earthly $EARTHLY_ARGS -P +build --area="$HEADWAY_AREA" --countries="$HEADWAY_COUNTRIES" --is_planet_build="$HEADWAY_IS_PLANET_BUILD"
 
 bin/build-transit "$CONFIG_DIR" $EARTHLY_ARGS
 

--- a/services/tilebuilder/percent-of-available-memory
+++ b/services/tilebuilder/percent-of-available-memory
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+# Calculate 75% of total available memory
+if [ -z "$1" ]; then
+
+    cat << EOS >&2
+Missing arg. Should be like:
+    # 75 percent of memory
+    # example output
+    $0 75
+    1234M
+EOS
+
+    exit 1
+fi
+
+MEM_PERCENT=$1
+
+AVAILABLE_KB=$(grep MemAvailable /proc/meminfo | awk '{print $2}')
+
+OUTPUT="$(( $AVAILABLE_KB * $MEM_PERCENT / 100 / 1024 ))M"
+echo "${MEM_PERCENT}% of available memory is $OUTPUT" >&2
+echo $OUTPUT
+


### PR DESCRIPTION
Some really impressive file-size gains. I just need to test these new planet assets before merging.

```
# planetiler 0.5
115G    maps-earth-planet-v1.36/maps-earth-planet-v1.36.mbtiles

# planetiler 0.7
86G     maps-earth-planet-v1.40/maps-earth-planet-v1.40.mbtiles
```

Note that this is also comparing two different planet inputs, so it's not a great test, but the planet build process is so slow that I'm not willing to run a more precise experiment at the moment.