### PR TITLE
[travelmux] maneuver data

### DIFF
--- a/services/travelmux/src/valhalla/valhalla_api.rs
+++ b/services/travelmux/src/valhalla/valhalla_api.rs
@@ -78,7 +78,7 @@ pub struct LngLat {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Leg {
     pub summary: Summary,
-    // pub maneuvers: Vec<Maneuver>,
+    pub maneuvers: Vec<Maneuver>,
     pub shape: String,
     // pub duration: f64,
     // pub length: f64,
@@ -87,11 +87,68 @@ pub struct Leg {
     pub extra: HashMap<String, serde_json::Value>,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "camelCase", deserialize = "snake_case"))]
+pub struct Maneuver {
+    pub instruction: String,
+    pub cost: f64,
+    pub begin_shape_index: u64,
+    pub end_shape_index: u64,
+    pub highway: Option<bool>,
+    pub length: f64,
+    pub street_names: Option<Vec<String>>,
+    pub time: f64,
+    pub travel_mode: String,
+    pub travel_type: String,
+    pub r#type: u64,
+    pub verbal_post_transition_instruction: Option<String>,
+    pub verbal_pre_transition_instruction: String,
+    pub verbal_succinct_transition_instruction: Option<String>,
+}
+
 impl From<Point> for LngLat {
     fn from(value: Point) -> Self {
         Self {
             lat: value.y(),
             lon: value.x(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_maneuver_from_json() {
+        // deserialize a maneuever from a JSON string
+        let json = r#"
+        {
+            "begin_shape_index": 0,
+            "cost": 246.056,
+            "end_shape_index": 69,
+            "highway": true,
+            "instruction": "Drive northeast on Fauntleroy Way Southwest.",
+            "length": 2.218,
+            "street_names": [
+            "Fauntleroy Way Southwest"
+            ],
+            "time": 198.858,
+            "travel_mode": "drive",
+            "travel_type": "car",
+            "type": 2,
+            "verbal_post_transition_instruction": "Continue for 2 miles.",
+            "verbal_pre_transition_instruction": "Drive northeast on Fauntleroy Way Southwest.",
+            "verbal_succinct_transition_instruction": "Drive northeast."
+        }"#;
+
+        let maneuver: Maneuver = serde_json::from_str(json).unwrap();
+        assert_eq!(maneuver.r#type, 2);
+        assert_eq!(
+            maneuver.instruction,
+            "Drive northeast on Fauntleroy Way Southwest."
+        );
+
+        assert_eq!(maneuver.highway, Some(true));
     }
 }


### PR DESCRIPTION
Remember, travelmux now combines responses from Valhalla and OTP. 

Put the per-leg maneuver data into the coalesced "Travelmux" legs, currently it's only valhalla maneuvers in the legs, but more to follow soon!

