### PR TITLE
[www] Fix valhalla routing instructions

### DIFF
--- a/services/travelmux/src/valhalla/valhalla_api.rs
+++ b/services/travelmux/src/valhalla/valhalla_api.rs
@@ -88,7 +88,6 @@ pub struct Leg {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all(serialize = "camelCase", deserialize = "snake_case"))]
 pub struct Maneuver {
     pub instruction: String,
     pub cost: f64,


### PR DESCRIPTION
Clicking on a route step and non-transit routing was not rendering.

I broke this while working on the travelmux API unification. I
unwittingly committed some code to the wrong file that made valhalla api
responses camelcase.

OTP is camelCase and Valhalla is snake_case. I decided to adopt
camelCase for the unified responses, but my intention was always to
leave the original _valhalla and _otp responses untouched so that legacy
clients could easily migrate.
