### PR TITLE
Use es8 container with pelias

### DIFF
--- a/bin/_headway_version.sh
+++ b/bin/_headway_version.sh
@@ -21,9 +21,14 @@
 # A bump in the DATA tag pretty much always implies a bump in the CONTAINER
 # tag, but not necessarily vice-versa.
 
-export HEADWAY_DATA_TAG=0.7.0
+export HEADWAY_DATA_TAG=0.8.0
 
 # # Schema change Log
+#
+# ## DATA v0.8.0, CONTAINER v0.10.0
+#
+# BREAKING DATA: pelias is now on es8
+# BREAKING CONTAINER: travelmux added api v3, removed v1
 #
 # ## DATA v0.7.0, CONTAINER v0.9.0
 #

--- a/docker-compose-with-transit.yaml
+++ b/docker-compose-with-transit.yaml
@@ -184,7 +184,7 @@ services:
       pelias-placeholder-init:
         condition: service_completed_successfully
   pelias-elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:8.12.2-beta
     restart: always
     networks:
       - pelias_backend

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -157,7 +157,7 @@ services:
       pelias-placeholder-init:
         condition: service_completed_successfully
   pelias-elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:8.12.2-beta
     restart: always
     networks:
       - pelias_backend

--- a/k8s/_template/pelias-elasticsearch-deployment.yaml.tpl
+++ b/k8s/_template/pelias-elasticsearch-deployment.yaml.tpl
@@ -63,7 +63,7 @@ spec:
               memory: 100Mi
       containers:
         - name: main
-          image: pelias/elasticsearch:7.16.1
+          image: pelias/elasticsearch:8.12.2-beta
           volumeMounts:
             - name: elasticsearch-volume
               mountPath: /usr/share/elasticsearch/data

--- a/k8s/configs/planet-dev/deployment-config.yaml
+++ b/k8s/configs/planet-dev/deployment-config.yaml
@@ -11,12 +11,12 @@ data:
   www-about-link-text: "About maps.earth"
   www-contact-url: "mailto:info@maps.earth?subject=Hello,%20Earth"
   www-contact-link-text: "Contact Us"
-  terrain-source-url: https://data.example.com/0.7.0/terrain.mbtiles
-  landcover-source-url: https://data.example.com/0.7.0/landcover.mbtiles
-  areamap-source-url: https://data.example.com/0.7.0/maps-earth-planet-v1.42/maps-earth-planet-v1.42.mbtiles
-  valhalla-artifact-url: https://data.example.com/0.7.0/maps-earth-planet-v1.42/maps-earth-planet-v1.42.valhalla.tar.zst
-  placeholder-artifact-url: https://data.example.com/0.7.0/maps-earth-planet-v1.42/maps-earth-planet-v1.42.placeholder.tar.zst
-  elasticsearch-artifact-url: https://data.example.com/0.7.0/maps-earth-planet-v1.42/maps-earth-planet-v1.42.elasticsearch.tar.zst
+  terrain-source-url: https://data.example.com/0.8.0/terrain.mbtiles
+  landcover-source-url: https://data.example.com/0.8.0/landcover.mbtiles
+  areamap-source-url: https://data.example.com/0.8.0/maps-earth-planet-v1.42/maps-earth-planet-v1.42.mbtiles
+  valhalla-artifact-url: https://data.example.com/0.8.0/maps-earth-planet-v1.42/maps-earth-planet-v1.42.valhalla.tar.zst
+  placeholder-artifact-url: https://data.example.com/0.8.0/maps-earth-planet-v1.42/maps-earth-planet-v1.42.placeholder.tar.zst
+  elasticsearch-artifact-url: https://data.example.com/0.8.0/maps-earth-planet-v1.42/maps-earth-planet-v1.42.elasticsearch.tar.zst
   pelias-config-json: |
     {
       "logger": {

--- a/k8s/configs/planet-dev/opentripplanner-barcelona-config.yaml
+++ b/k8s/configs/planet-dev/opentripplanner-barcelona-config.yaml
@@ -3,6 +3,6 @@ kind: ConfigMap
 metadata:
   name: otp-barcelona-config
 data:
-  graph-url: https://data.example.com/0.7.0/maps-earth-planet-v1.42/Barcelona.graph.obj.zst
+  graph-url: https://data.example.com/0.8.0/maps-earth-planet-v1.42/Barcelona.graph.obj.zst
   router-config-json: ""
 

--- a/k8s/configs/planet-dev/opentripplanner-losangeles-config.yaml
+++ b/k8s/configs/planet-dev/opentripplanner-losangeles-config.yaml
@@ -3,6 +3,6 @@ kind: ConfigMap
 metadata:
   name: otp-losangeles-config
 data:
-  graph-url: https://data.example.com/0.7.0/maps-earth-planet-v1.42/LosAngeles.graph.obj.zst
+  graph-url: https://data.example.com/0.8.0/maps-earth-planet-v1.42/LosAngeles.graph.obj.zst
   router-config-json: ""
 

--- a/k8s/configs/planet-dev/opentripplanner-pugetsound-config.yaml
+++ b/k8s/configs/planet-dev/opentripplanner-pugetsound-config.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: otp-pugetsound-config
 data:
-  graph-url: https://data.example.com/0.7.0/maps-earth-planet-v1.42/PugetSound.graph.obj.zst
+  graph-url: https://data.example.com/0.8.0/maps-earth-planet-v1.42/PugetSound.graph.obj.zst
   router-config-json: |
     {
       "configVersion": "2023-05-24",

--- a/k8s/configs/planet-dev/pelias-elasticsearch-deployment.yaml
+++ b/k8s/configs/planet-dev/pelias-elasticsearch-deployment.yaml
@@ -63,7 +63,7 @@ spec:
               memory: 100Mi
       containers:
         - name: main
-          image: pelias/elasticsearch:7.16.1
+          image: pelias/elasticsearch:8.12.2-beta
           volumeMounts:
             - name: elasticsearch-volume
               mountPath: /usr/share/elasticsearch/data

--- a/k8s/configs/planet/deployment-config.yaml
+++ b/k8s/configs/planet/deployment-config.yaml
@@ -11,12 +11,12 @@ data:
   www-about-link-text: "About maps.earth"
   www-contact-url: "mailto:info@maps.earth?subject=Hello,%20Earth"
   www-contact-link-text: "Contact Us"
-  terrain-source-url: https://data.example.com/0.7.0/terrain.mbtiles
-  landcover-source-url: https://data.example.com/0.7.0/landcover.mbtiles
-  areamap-source-url: https://data.example.com/0.7.0/maps-earth-planet-v1.42/maps-earth-planet-v1.42.mbtiles
-  valhalla-artifact-url: https://data.example.com/0.7.0/maps-earth-planet-v1.42/maps-earth-planet-v1.42.valhalla.tar.zst
-  placeholder-artifact-url: https://data.example.com/0.7.0/maps-earth-planet-v1.42/maps-earth-planet-v1.42.placeholder.tar.zst
-  elasticsearch-artifact-url: https://data.example.com/0.7.0/maps-earth-planet-v1.42/maps-earth-planet-v1.42.elasticsearch.tar.zst
+  terrain-source-url: https://data.example.com/0.8.0/terrain.mbtiles
+  landcover-source-url: https://data.example.com/0.8.0/landcover.mbtiles
+  areamap-source-url: https://data.example.com/0.8.0/maps-earth-planet-v1.42/maps-earth-planet-v1.42.mbtiles
+  valhalla-artifact-url: https://data.example.com/0.8.0/maps-earth-planet-v1.42/maps-earth-planet-v1.42.valhalla.tar.zst
+  placeholder-artifact-url: https://data.example.com/0.8.0/maps-earth-planet-v1.42/maps-earth-planet-v1.42.placeholder.tar.zst
+  elasticsearch-artifact-url: https://data.example.com/0.8.0/maps-earth-planet-v1.42/maps-earth-planet-v1.42.elasticsearch.tar.zst
   pelias-config-json: |
     {
       "logger": {

--- a/k8s/configs/planet/opentripplanner-barcelona-config.yaml
+++ b/k8s/configs/planet/opentripplanner-barcelona-config.yaml
@@ -3,6 +3,6 @@ kind: ConfigMap
 metadata:
   name: otp-barcelona-config
 data:
-  graph-url: https://data.example.com/0.7.0/maps-earth-planet-v1.42/Barcelona.graph.obj.zst
+  graph-url: https://data.example.com/0.8.0/maps-earth-planet-v1.42/Barcelona.graph.obj.zst
   router-config-json: ""
 

--- a/k8s/configs/planet/opentripplanner-losangeles-config.yaml
+++ b/k8s/configs/planet/opentripplanner-losangeles-config.yaml
@@ -3,6 +3,6 @@ kind: ConfigMap
 metadata:
   name: otp-losangeles-config
 data:
-  graph-url: https://data.example.com/0.7.0/maps-earth-planet-v1.42/LosAngeles.graph.obj.zst
+  graph-url: https://data.example.com/0.8.0/maps-earth-planet-v1.42/LosAngeles.graph.obj.zst
   router-config-json: ""
 

--- a/k8s/configs/planet/opentripplanner-pugetsound-config.yaml
+++ b/k8s/configs/planet/opentripplanner-pugetsound-config.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: otp-pugetsound-config
 data:
-  graph-url: https://data.example.com/0.7.0/maps-earth-planet-v1.42/PugetSound.graph.obj.zst
+  graph-url: https://data.example.com/0.8.0/maps-earth-planet-v1.42/PugetSound.graph.obj.zst
   router-config-json: |
     {
       "updaters": [

--- a/k8s/configs/planet/pelias-elasticsearch-deployment.yaml
+++ b/k8s/configs/planet/pelias-elasticsearch-deployment.yaml
@@ -63,7 +63,7 @@ spec:
               memory: 100Mi
       containers:
         - name: main
-          image: pelias/elasticsearch:7.16.1
+          image: pelias/elasticsearch:8.12.2-beta
           volumeMounts:
             - name: elasticsearch-volume
               mountPath: /usr/share/elasticsearch/data

--- a/k8s/configs/seattle-dev/pelias-elasticsearch-deployment.yaml
+++ b/k8s/configs/seattle-dev/pelias-elasticsearch-deployment.yaml
@@ -63,7 +63,7 @@ spec:
               memory: 100Mi
       containers:
         - name: main
-          image: pelias/elasticsearch:7.16.1
+          image: pelias/elasticsearch:8.12.2-beta
           volumeMounts:
             - name: elasticsearch-volume
               mountPath: /usr/share/elasticsearch/data

--- a/services/pelias/docker-compose-import.yaml
+++ b/services/pelias/docker-compose-import.yaml
@@ -9,9 +9,7 @@ services:
     depends_on:
       - pelias_elasticsearch
   pelias_whosonfirst:
-    # Occasionally the containers need to be updated to fit the ever-growing dataset
-    # See https://github.com/pelias/whosonfirst/pull/540
-    image: ghcr.io/michaelkirk-pelias/whosonfirst:bump-importer-mem
+    image: pelias/whosonfirst:master
     container_name: pelias_whosonfirst
     volumes:
       - "./pelias.json:/code/pelias.json"

--- a/services/pelias/docker-compose-import.yaml
+++ b/services/pelias/docker-compose-import.yaml
@@ -58,7 +58,7 @@ services:
     depends_on:
       - pelias_elasticsearch
   pelias_elasticsearch:
-    image: pelias/elasticsearch:7.16.1
+    image: pelias/elasticsearch:8.12.2-beta
     container_name: pelias_elasticsearch
     volumes:
       - "${DATA_DIR}/elasticsearch:/usr/share/elasticsearch/data"


### PR DESCRIPTION
es8 support for pelias is experimental. I've done a test build and have been running it in production for a couple of days now seemingly without issue.

Note the pelias code still uses the legacy elasticsearch client. It just takes advantage of that fact that es8 is backwards compatible with the legacy client.

See https://github.com/pelias/pelias/issues/953 for more

