### PR TITLE
[travelmux] add start/end to each trip leg

### DIFF
--- a/services/travelmux/src/otp/otp_api.rs
+++ b/services/travelmux/src/otp/otp_api.rs
@@ -73,6 +73,16 @@ pub struct Leg {
     pub route_color: Option<String>,
     // Present, but empty, for transit legs. Non-empty for non-transit legs.
     pub steps: Vec<Step>,
+
+    pub from: Place,
+    pub to: Place,
+
+    /// What time the leg starts, in millis since Unix epoch (UTC)
+    pub start_time: u64,
+
+    /// What time the leg starts, in millis since Unix epoch (UTC)
+    pub end_time: u64,
+
     #[serde(flatten)]
     pub extra: HashMap<String, serde_json::Value>,
 }
@@ -160,11 +170,34 @@ pub struct LegGeometry {
     pub points: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Clone, Copy)]
 #[serde(rename_all = "camelCase")]
-pub struct Location {
+pub struct LonLat {
     pub lat: f64,
     pub lon: f64,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Place {
+    #[serde(flatten)]
+    pub location: LonLat,
+
+    /// millis since Unix epoch
+    /// I think it's None iff it's the trip Origin
+    pub arrival: Option<u64>,
+
+    /// millis since Unix epoch
+    /// I think it's None iff it's the trip Destination
+    pub departure: Option<u64>,
+
+    /// "Civic Center / Grand Park Station"
+    /// Transit stops often have names. But this is often blank when
+    /// the place is some random lat/lon (e.g. the users destination)
+    pub name: Option<String>,
+
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
 }
 
 #[cfg(test)]

--- a/services/travelmux/src/valhalla/valhalla_api.rs
+++ b/services/travelmux/src/valhalla/valhalla_api.rs
@@ -1,3 +1,4 @@
+use crate::otp::otp_api;
 use crate::DistanceUnit;
 use geo::Point;
 use serde::{Deserialize, Serialize};
@@ -16,7 +17,7 @@ pub enum ModeCosting {
 ///     `route?json={%22locations%22:[{%22lat%22:47.575837,%22lon%22:-122.339414},{%22lat%22:47.651048,%22lon%22:-122.347234}],%22costing%22:%22auto%22,%22alternates%22:3,%22units%22:%22miles%22}`
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ValhallaRouteQuery {
-    pub locations: Vec<LngLat>,
+    pub locations: Vec<LonLat>,
     pub costing: ModeCosting,
     pub alternates: u32,
     pub units: DistanceUnit,
@@ -47,7 +48,7 @@ pub enum ValhallaRouteResponseResult {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Trip {
-    pub locations: Vec<LngLat>,
+    pub locations: Vec<LonLat>,
     pub summary: Summary,
     pub units: DistanceUnit, // legs: Vec<Leg>
     pub legs: Vec<Leg>,
@@ -74,11 +75,10 @@ pub struct Summary {
     pub extra: HashMap<String, serde_json::Value>,
 }
 
-// CLEANUP: rename to LonLat to match their field spelling?
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct LngLat {
-    pub lat: f64,
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct LonLat {
     pub lon: f64,
+    pub lat: f64,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -86,7 +86,6 @@ pub struct Leg {
     pub summary: Summary,
     pub maneuvers: Vec<Maneuver>,
     pub shape: String,
-    // pub duration: f64,
     // pub length: f64,
     // pub steps: Vec<Step>,
     #[serde(flatten)]
@@ -175,11 +174,26 @@ pub enum ManeuverType {
     BuildingExit = 43,
 }
 
-impl From<Point> for LngLat {
+impl From<Point> for LonLat {
     fn from(value: Point) -> Self {
         Self {
             lat: value.y(),
             lon: value.x(),
+        }
+    }
+}
+
+impl From<LonLat> for Point {
+    fn from(value: LonLat) -> Self {
+        geo::point!(x: value.lon, y: value.lat)
+    }
+}
+
+impl From<otp_api::LonLat> for LonLat {
+    fn from(value: otp_api::LonLat) -> Self {
+        Self {
+            lon: value.lon,
+            lat: value.lat,
         }
     }
 }


### PR DESCRIPTION
This allows building a transit timeline without accessing the raw OTP response.