### PR TITLE
Allow universal links for iOS native app

### DIFF
--- a/services/frontend/www-app/public/.well-known/apple-app-site-association
+++ b/services/frontend/www-app/public/.well-known/apple-app-site-association
@@ -1,0 +1,27 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": [ "CSBZ6R9U39.earth.maps.maps-earth" ],
+        "components": [
+          {
+            "/": "",
+            "comment": "Show the root / home screen."
+          },
+          {
+            "/": "/",
+            "comment": "Show the root / home screen."
+          },
+          {
+            "/": "/place/?*",
+            "comment": "Show the details of a specific place."
+          },
+          {
+            "/": "/directions/?*",
+            "comment": "Show the details of a specific place."
+          },
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Currently this is hardcoded to the maps.earth iOS app, but I'm happy to template this if someone cares and wants to do the leg work.

In the meanwhile, it won't have any affect for other domains unless the iOS app is updated to work with those domains.
