### PR TITLE
build: make assets download URLs configurable

### DIFF
--- a/dagger/transit.go
+++ b/dagger/transit.go
@@ -142,7 +142,8 @@ func (t *TransitZone) BBox(ctx context.Context) (*Bbox, error) {
 
 // Downloads GTFS mobility database CSV
 func (h *Headway) GtfsGetMobilitydb(ctx context.Context) *dagger.File {
-	return downloadFile("https://storage.googleapis.com/storage/v1/b/mdb-csv/o/sources.csv?alt=media")
+	downloadUrl := getEnvWithDefault("HEADWAY_MOBILITYDB_URL", "https://storage.googleapis.com/storage/v1/b/mdb-csv/o/sources.csv?alt=media")
+	return downloadFile(downloadUrl)
 }
 
 // Enumerates GTFS feeds for a given area by filtering the mobility database


### PR DESCRIPTION
New optional build-time env vars to configure where to download remote assets from:
- `HEADWAY_TILES_URL` (default https://github.com/headwaymaps/headway-data/raw/main/tiles/)
- `HEADWAY_PLANETILER_FIXTURES_URL` (default https://data.maps.earth/planetiler_fixtures/sources.tar)
- `HEADWAY_PBF_URL` (default https://download.bbbike.org/osm/bbbike)
- `HEADWAY_MOBILITYDB_URL` (default https://storage.googleapis.com/storage/v1/b/mdb-csv/o/sources.csv?alt=media)

---
Follow-up to #387 